### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/483/689/3/1444836893.geojson
+++ b/data/144/483/689/3/1444836893.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"eb0796d12140dfb02bdd6e8349d70d00",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836893,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836893,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338947,
     "wof:name":"Old Town",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/689/3/1444836893.geojson
+++ b/data/144/483/689/3/1444836893.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836893,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7530079305,42.1493167729,24.7530079305,42.1493167729",
+    "geom:latitude":42.149317,
+    "geom:longitude":24.753008,
+    "iso:country":"BG",
+    "lbl:latitude":42.149317,
+    "lbl:longitude":24.753008,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Starijat grad"
+    ],
+    "name:eng_x_preferred":[
+        "\u0421\u0442\u0430\u0440\u0438\u044f\u0442 \u0433\u0440\u0430\u0434"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"eb0796d12140dfb02bdd6e8349d70d00",
+    "wof:hierarchy":[],
+    "wof:id":1444836893,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Old Town",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.75300793050726,
+    42.14931677289402,
+    24.75300793050726,
+    42.14931677289402
+],
+  "geometry": {"coordinates":[24.75300793050726,42.14931677289402],"type":"Point"}
+}

--- a/data/144/483/690/5/1444836905.geojson
+++ b/data/144/483/690/5/1444836905.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"2ae1e645ee99b96d8a2a54ab8ed80f23",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836905,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836905,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338948,
     "wof:name":"Center",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/690/5/1444836905.geojson
+++ b/data/144/483/690/5/1444836905.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836905,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7453834438,42.1443426857,24.7453834438,42.1443426857",
+    "geom:latitude":42.144343,
+    "geom:longitude":24.745383,
+    "iso:country":"BG",
+    "lbl:latitude":42.144343,
+    "lbl:longitude":24.745383,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Cent\"r"
+    ],
+    "name:eng_x_preferred":[
+        "\u0426\u0435\u043d\u0442\u044a\u0440"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"2ae1e645ee99b96d8a2a54ab8ed80f23",
+    "wof:hierarchy":[],
+    "wof:id":1444836905,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Center",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.74538344376712,
+    42.14434268568731,
+    24.74538344376712,
+    42.14434268568731
+],
+  "geometry": {"coordinates":[24.74538344376712,42.14434268568731],"type":"Point"}
+}

--- a/data/144/483/691/7/1444836917.geojson
+++ b/data/144/483/691/7/1444836917.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836917,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.735083756,42.1506214999,24.735083756,42.1506214999",
+    "geom:latitude":42.150621,
+    "geom:longitude":24.735084,
+    "iso:country":"BG",
+    "lbl:latitude":42.150621,
+    "lbl:longitude":24.735084,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041c\u0430\u0440\u0430\u0448\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"b0846b6e3d632f2fd8136354dc19267c",
+    "wof:hierarchy":[],
+    "wof:id":1444836917,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Marasha",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.735083755967626,
+    42.15062149994724,
+    24.735083755967626,
+    42.15062149994724
+],
+  "geometry": {"coordinates":[24.73508375596763,42.15062149994724],"type":"Point"}
+}

--- a/data/144/483/691/7/1444836917.geojson
+++ b/data/144/483/691/7/1444836917.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"b0846b6e3d632f2fd8136354dc19267c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a08bd9cc7e4eb950fa040d65c66f4ff7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836917,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836917,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338951,
     "wof:name":"Marasha",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.735083755967626,
+    24.73508375596763,
     42.15062149994724,
-    24.735083755967626,
+    24.73508375596763,
     42.15062149994724
 ],
   "geometry": {"coordinates":[24.73508375596763,42.15062149994724],"type":"Point"}

--- a/data/144/483/692/7/1444836927.geojson
+++ b/data/144/483/692/7/1444836927.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836927,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7670280401,42.142870352,24.7670280401,42.142870352",
+    "geom:latitude":42.14287,
+    "geom:longitude":24.767028,
+    "iso:country":"BG",
+    "lbl:latitude":42.14287,
+    "lbl:longitude":24.767028,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u0430\u043c\u0435\u043d\u0438\u0446\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"15a8d49759e5382cae666273f7e532da",
+    "wof:hierarchy":[],
+    "wof:id":1444836927,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Kamenitsa",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.76702804011528,
+    42.142870352044476,
+    24.76702804011528,
+    42.142870352044476
+],
+  "geometry": {"coordinates":[24.76702804011528,42.14287035204448],"type":"Point"}
+}

--- a/data/144/483/692/7/1444836927.geojson
+++ b/data/144/483/692/7/1444836927.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"15a8d49759e5382cae666273f7e532da",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bdb66829222ea2b31a71e7d67427af32",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836927,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836927,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338952,
     "wof:name":"Kamenitsa",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -43,9 +56,9 @@
 },
   "bbox": [
     24.76702804011528,
-    42.142870352044476,
+    42.14287035204448,
     24.76702804011528,
-    42.142870352044476
+    42.14287035204448
 ],
   "geometry": {"coordinates":[24.76702804011528,42.14287035204448],"type":"Point"}
 }

--- a/data/144/483/693/9/1444836939.geojson
+++ b/data/144/483/693/9/1444836939.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"9175ee222e2efa1651b72e2d83fe20fc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7a7ff3a04059bac305d3be91b4fda28a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836939,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836939,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338952,
     "wof:name":"Gladno Pole",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.778300476206955,
+    24.77830047620695,
     42.14673113988457,
-    24.778300476206955,
+    24.77830047620695,
     42.14673113988457
 ],
   "geometry": {"coordinates":[24.77830047620695,42.14673113988457],"type":"Point"}

--- a/data/144/483/693/9/1444836939.geojson
+++ b/data/144/483/693/9/1444836939.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836939,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7783004762,42.1467311399,24.7783004762,42.1467311399",
+    "geom:latitude":42.146731,
+    "geom:longitude":24.7783,
+    "iso:country":"BG",
+    "lbl:latitude":42.146731,
+    "lbl:longitude":24.7783,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0413\u043b\u0430\u0434\u043d\u043e \u043f\u043e\u043b\u0435"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"9175ee222e2efa1651b72e2d83fe20fc",
+    "wof:hierarchy":[],
+    "wof:id":1444836939,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Gladno Pole",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.778300476206955,
+    42.14673113988457,
+    24.778300476206955,
+    42.14673113988457
+],
+  "geometry": {"coordinates":[24.77830047620695,42.14673113988457],"type":"Point"}
+}

--- a/data/144/483/695/3/1444836953.geojson
+++ b/data/144/483/695/3/1444836953.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836953,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7850667989,42.155268576,24.7850667989,42.155268576",
+    "geom:latitude":42.155269,
+    "geom:longitude":24.785067,
+    "iso:country":"BG",
+    "lbl:latitude":42.155268,
+    "lbl:longitude":24.785067,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0421\u0442\u043e\u043b\u0438\u043f\u0438\u043d\u043e\u0432\u043e"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"e4b2605329e9461be691ae4b87e14447",
+    "wof:hierarchy":[],
+    "wof:id":1444836953,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Stolipinovo",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.78506679888636,
+    42.15526857603795,
+    24.78506679888636,
+    42.15526857603795
+],
+  "geometry": {"coordinates":[24.78506679888636,42.15526857603795],"type":"Point"}
+}

--- a/data/144/483/695/3/1444836953.geojson
+++ b/data/144/483/695/3/1444836953.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"e4b2605329e9461be691ae4b87e14447",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836953,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836953,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338953,
     "wof:name":"Stolipinovo",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/696/1/1444836961.geojson
+++ b/data/144/483/696/1/1444836961.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836961,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7912466116,42.153317263,24.7912466116,42.153317263",
+    "geom:latitude":42.153317,
+    "geom:longitude":24.791247,
+    "iso:country":"BG",
+    "lbl:latitude":42.153317,
+    "lbl:longitude":24.791247,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0418\u0437\u0433\u0440\u0435\u0432"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"beaff3c4b0aca6b619578b3d57ea66be",
+    "wof:hierarchy":[],
+    "wof:id":1444836961,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Izgrev",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.79124661156606,
+    42.15331726298899,
+    24.79124661156606,
+    42.15331726298899
+],
+  "geometry": {"coordinates":[24.79124661156606,42.15331726298899],"type":"Point"}
+}

--- a/data/144/483/696/1/1444836961.geojson
+++ b/data/144/483/696/1/1444836961.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"beaff3c4b0aca6b619578b3d57ea66be",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836961,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836961,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338956,
     "wof:name":"Izgrev",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/697/3/1444836973.geojson
+++ b/data/144/483/697/3/1444836973.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"6047ef0a35d4f1dfa8c997a306bd7347",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d11bdb54108537b3a2a965a59e46fe2f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836973,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836973,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338957,
     "wof:name":"Hadji Hasan Mahala",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -49,9 +62,9 @@
 },
   "bbox": [
     24.75865954377818,
-    42.147823569471846,
+    42.14782356947185,
     24.75865954377818,
-    42.147823569471846
+    42.14782356947185
 ],
   "geometry": {"coordinates":[24.75865954377818,42.14782356947185],"type":"Point"}
 }

--- a/data/144/483/697/3/1444836973.geojson
+++ b/data/144/483/697/3/1444836973.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836973,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7586595438,42.1478235695,24.7586595438,42.1478235695",
+    "geom:latitude":42.147824,
+    "geom:longitude":24.75866,
+    "iso:country":"BG",
+    "lbl:latitude":42.147824,
+    "lbl:longitude":24.75866,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "\u0410\u0434\u0436\u0438\u0441\u0430\u043d \u043c\u0430\u0445\u0430\u043b\u0430"
+    ],
+    "name:eng_x_preferred":[
+        "\u0425\u0430\u0434\u0436\u0438 \u0425\u0430\u0441\u0430\u043d \u043c\u0430\u0445\u0430\u043b\u0430"
+    ],
+    "name:eng_x_variant":[
+        "Adjans Mahala"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"6047ef0a35d4f1dfa8c997a306bd7347",
+    "wof:hierarchy":[],
+    "wof:id":1444836973,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Hadji Hasan Mahala",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.75865954377818,
+    42.147823569471846,
+    24.75865954377818,
+    42.147823569471846
+],
+  "geometry": {"coordinates":[24.75865954377818,42.14782356947185],"type":"Point"}
+}

--- a/data/144/483/698/3/1444836983.geojson
+++ b/data/144/483/698/3/1444836983.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"ff592361ab12ae0d8076aa6da3a56e13",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1e4de2672f5a1939095c6a2d041f85f2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":-1,
+            "neighbourhood_id":1444836983,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836983,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338958,
     "wof:name":"Industrial Zone-East",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +57,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.804636205705417,
+    24.80463620570542,
     42.14722962809992,
-    24.804636205705417,
+    24.80463620570542,
     42.14722962809992
 ],
   "geometry": {"coordinates":[24.80463620570542,42.14722962809992],"type":"Point"}

--- a/data/144/483/698/3/1444836983.geojson
+++ b/data/144/483/698/3/1444836983.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836983,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.8046362057,42.1472296281,24.8046362057,42.1472296281",
+    "geom:latitude":42.14723,
+    "geom:longitude":24.804636,
+    "iso:country":"BG",
+    "lbl:latitude":42.14723,
+    "lbl:longitude":24.804636,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Industrialna zona iztok"
+    ],
+    "name:eng_x_preferred":[
+        "\u0418\u043d\u0434\u0443\u0441\u0442\u0440\u0438\u0430\u043b\u043d\u0430 \u0437\u043e\u043d\u0430 \u0438\u0437\u0442\u043e\u043a"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"ff592361ab12ae0d8076aa6da3a56e13",
+    "wof:hierarchy":[],
+    "wof:id":1444836983,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Industrial Zone-East",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.804636205705417,
+    42.14722962809992,
+    24.804636205705417,
+    42.14722962809992
+],
+  "geometry": {"coordinates":[24.80463620570542,42.14722962809992],"type":"Point"}
+}

--- a/data/144/483/699/5/1444836995.geojson
+++ b/data/144/483/699/5/1444836995.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"104edd8ccd30ebbb079027bb2df0763d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"df39c3e126b53e6ccf19f6851158e3e5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444836995,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444836995,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338958,
     "wof:name":"Trakia",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.788042264250663,
+    24.78804226425066,
     42.1341190747433,
-    24.788042264250663,
+    24.78804226425066,
     42.1341190747433
 ],
   "geometry": {"coordinates":[24.78804226425066,42.1341190747433],"type":"Point"}

--- a/data/144/483/699/5/1444836995.geojson
+++ b/data/144/483/699/5/1444836995.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836995,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7880422643,42.1341190747,24.7880422643,42.1341190747",
+    "geom:latitude":42.134119,
+    "geom:longitude":24.788042,
+    "iso:country":"BG",
+    "lbl:latitude":42.134119,
+    "lbl:longitude":24.788042,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0422\u0440\u0430\u043a\u0438\u044f"
+    ],
+    "name:eng_x_variant":[
+        "Trakiya"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"104edd8ccd30ebbb079027bb2df0763d",
+    "wof:hierarchy":[],
+    "wof:id":1444836995,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Trakia",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.788042264250663,
+    42.1341190747433,
+    24.788042264250663,
+    42.1341190747433
+],
+  "geometry": {"coordinates":[24.78804226425066,42.1341190747433],"type":"Point"}
+}

--- a/data/144/483/700/7/1444837007.geojson
+++ b/data/144/483/700/7/1444837007.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"c1cceddfd64135af3e322a8ca1cf63ea",
-    "wof:hierarchy":[],
+    "wof:geomhash":"74a8138956c0a41bf3e275cbad4618bb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837007,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837007,
-    "wof:lastmodified":1566333621,
+    "wof:lastmodified":1566338961,
     "wof:name":"Ljuljacite",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.776397894988452,
+    24.77639789498845,
     42.12641695008374,
-    24.776397894988452,
+    24.77639789498845,
     42.12641695008374
 ],
   "geometry": {"coordinates":[24.77639789498845,42.12641695008374],"type":"Point"}

--- a/data/144/483/700/7/1444837007.geojson
+++ b/data/144/483/700/7/1444837007.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837007,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.776397895,42.1264169501,24.776397895,42.1264169501",
+    "geom:latitude":42.126417,
+    "geom:longitude":24.776398,
+    "iso:country":"BG",
+    "lbl:latitude":42.126417,
+    "lbl:longitude":24.776398,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "\u04101"
+    ],
+    "name:eng_x_preferred":[
+        "\u041b\u044e\u043b\u044f\u0446\u0438\u0442\u0435"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"c1cceddfd64135af3e322a8ca1cf63ea",
+    "wof:hierarchy":[],
+    "wof:id":1444837007,
+    "wof:lastmodified":1566333621,
+    "wof:name":"Ljuljacite",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.776397894988452,
+    42.12641695008374,
+    24.776397894988452,
+    42.12641695008374
+],
+  "geometry": {"coordinates":[24.77639789498845,42.12641695008374],"type":"Point"}
+}

--- a/data/144/483/701/7/1444837017.geojson
+++ b/data/144/483/701/7/1444837017.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837017,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7797452935,42.1289844291,24.7797452935,42.1289844291",
+    "geom:latitude":42.128984,
+    "geom:longitude":24.779745,
+    "iso:country":"BG",
+    "lbl:latitude":42.128984,
+    "lbl:longitude":24.779745,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A2"
+    ],
+    "name:eng_x_preferred":[
+        "\u041f\u0430\u043d\u0430\u0439\u043e\u0442 \u0412\u043e\u043b\u043e\u0432"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"ff4f957211091482e0e47025418c4d35",
+    "wof:hierarchy":[],
+    "wof:id":1444837017,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Panajot Volov",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.77974529352329,
+    42.128984429128366,
+    24.77974529352329,
+    42.128984429128366
+],
+  "geometry": {"coordinates":[24.77974529352329,42.12898442912837],"type":"Point"}
+}

--- a/data/144/483/701/7/1444837017.geojson
+++ b/data/144/483/701/7/1444837017.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"ff4f957211091482e0e47025418c4d35",
-    "wof:hierarchy":[],
+    "wof:geomhash":"51f64b1a89c9950f188d988f1c56ddcd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837017,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837017,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338962,
     "wof:name":"Panajot Volov",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -46,9 +59,9 @@
 },
   "bbox": [
     24.77974529352329,
-    42.128984429128366,
+    42.12898442912837,
     24.77974529352329,
-    42.128984429128366
+    42.12898442912837
 ],
   "geometry": {"coordinates":[24.77974529352329,42.12898442912837],"type":"Point"}
 }

--- a/data/144/483/702/9/1444837029.geojson
+++ b/data/144/483/702/9/1444837029.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837029,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7839509994,42.1287722447,24.7839509994,42.1287722447",
+    "geom:latitude":42.128772,
+    "geom:longitude":24.783951,
+    "iso:country":"BG",
+    "lbl:latitude":42.128772,
+    "lbl:longitude":24.783951,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A3"
+    ],
+    "name:eng_x_preferred":[
+        "\u0422\u043e\u0434\u043e\u0440 \u041a\u0430\u0431\u043b\u0435\u0448\u043a\u043e\u0432"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"f21705a6fdc3d8e768151b3eeb3d1424",
+    "wof:hierarchy":[],
+    "wof:id":1444837029,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Todor Kableshkov",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.783950999374756,
+    42.12877224473445,
+    24.783950999374756,
+    42.12877224473445
+],
+  "geometry": {"coordinates":[24.78395099937476,42.12877224473445],"type":"Point"}
+}

--- a/data/144/483/702/9/1444837029.geojson
+++ b/data/144/483/702/9/1444837029.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"f21705a6fdc3d8e768151b3eeb3d1424",
-    "wof:hierarchy":[],
+    "wof:geomhash":"63f0173431e7d9a5664379f550c7c63f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837029,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837029,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338963,
     "wof:name":"Todor Kableshkov",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.783950999374756,
+    24.78395099937476,
     42.12877224473445,
-    24.783950999374756,
+    24.78395099937476,
     42.12877224473445
 ],
   "geometry": {"coordinates":[24.78395099937476,42.12877224473445],"type":"Point"}

--- a/data/144/483/703/9/1444837039.geojson
+++ b/data/144/483/703/9/1444837039.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"0fe3b41b32034bb62d41517b7e6910dc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a2d3dca5e82238e9668b1f3008d74af7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837039,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837039,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338963,
     "wof:name":"Kan Krum",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.789587217420596,
+    24.7895872174206,
     42.13034239241922,
-    24.789587217420596,
+    24.7895872174206,
     42.13034239241922
 ],
   "geometry": {"coordinates":[24.7895872174206,42.13034239241922],"type":"Point"}

--- a/data/144/483/703/9/1444837039.geojson
+++ b/data/144/483/703/9/1444837039.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837039,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7895872174,42.1303423924,24.7895872174,42.1303423924",
+    "geom:latitude":42.130342,
+    "geom:longitude":24.789587,
+    "iso:country":"BG",
+    "lbl:latitude":42.130342,
+    "lbl:longitude":24.789587,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A4"
+    ],
+    "name:eng_x_preferred":[
+        "\u041a\u0430\u043d \u041a\u0440\u0443\u043c"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"0fe3b41b32034bb62d41517b7e6910dc",
+    "wof:hierarchy":[],
+    "wof:id":1444837039,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Kan Krum",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.789587217420596,
+    42.13034239241922,
+    24.789587217420596,
+    42.13034239241922
+],
+  "geometry": {"coordinates":[24.7895872174206,42.13034239241922],"type":"Point"}
+}

--- a/data/144/483/705/1/1444837051.geojson
+++ b/data/144/483/705/1/1444837051.geojson
@@ -1,0 +1,55 @@
+{
+  "id": 1444837051,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7913896628,42.1336098723,24.7913896628,42.1336098723",
+    "geom:latitude":42.13361,
+    "geom:longitude":24.79139,
+    "iso:country":"BG",
+    "lbl:latitude":42.13361,
+    "lbl:longitude":24.79139,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A5",
+        "T\"rgovski"
+    ],
+    "name:eng_x_preferred":[
+        "\u0422\u044a\u0440\u0433\u043e\u0432\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"7688ec4bf8d7b9b8fe96b99906de4e2c",
+    "wof:hierarchy":[],
+    "wof:id":1444837051,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Turgovski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.79138966278551,
+    42.13360987228355,
+    24.79138966278551,
+    42.13360987228355
+],
+  "geometry": {"coordinates":[24.79138966278551,42.13360987228355],"type":"Point"}
+}

--- a/data/144/483/705/1/1444837051.geojson
+++ b/data/144/483/705/1/1444837051.geojson
@@ -30,15 +30,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"7688ec4bf8d7b9b8fe96b99906de4e2c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837051,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837051,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338966,
     "wof:name":"Turgovski",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/706/3/1444837063.geojson
+++ b/data/144/483/706/3/1444837063.geojson
@@ -1,0 +1,55 @@
+{
+  "id": 1444837063,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7968256091,42.131403281,24.7968256091,42.131403281",
+    "geom:latitude":42.131403,
+    "geom:longitude":24.796826,
+    "iso:country":"BG",
+    "lbl:latitude":42.131403,
+    "lbl:longitude":24.796826,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Op\"lchenski",
+        "A6"
+    ],
+    "name:eng_x_preferred":[
+        "\u041e\u043f\u044a\u043b\u0447\u0435\u043d\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"b12c01e8520a411a94a6edbec7da71ce",
+    "wof:hierarchy":[],
+    "wof:id":1444837063,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Opulchenski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.796825609124138,
+    42.131403280984266,
+    24.796825609124138,
+    42.131403280984266
+],
+  "geometry": {"coordinates":[24.79682560912414,42.13140328098427],"type":"Point"}
+}

--- a/data/144/483/706/3/1444837063.geojson
+++ b/data/144/483/706/3/1444837063.geojson
@@ -30,13 +30,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"b12c01e8520a411a94a6edbec7da71ce",
-    "wof:hierarchy":[],
+    "wof:geomhash":"beee40dd99259c7587e59111efa6bfaa",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":-1,
+            "neighbourhood_id":1444837063,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837063,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338967,
     "wof:name":"Opulchenski",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -46,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.796825609124138,
-    42.131403280984266,
-    24.796825609124138,
-    42.131403280984266
+    24.79682560912414,
+    42.13140328098427,
+    24.79682560912414,
+    42.13140328098427
 ],
   "geometry": {"coordinates":[24.79682560912414,42.13140328098427],"type":"Point"}
 }

--- a/data/144/483/707/3/1444837073.geojson
+++ b/data/144/483/707/3/1444837073.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837073,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7993433106,42.1374924376,24.7993433106,42.1374924376",
+    "geom:latitude":42.137492,
+    "geom:longitude":24.799343,
+    "iso:country":"BG",
+    "lbl:latitude":42.137492,
+    "lbl:longitude":24.799343,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A7"
+    ],
+    "name:eng_x_preferred":[
+        "\u041a\u0430\u043f\u0438\u0442\u0430\u043d \u0411\u0443\u0440\u0430\u0433\u043e"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"16cccd4d552e7f6b36c7ad65173de3a1",
+    "wof:hierarchy":[],
+    "wof:id":1444837073,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Kapitan Burago",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.799343310586234,
+    42.137492437636155,
+    24.799343310586234,
+    42.137492437636155
+],
+  "geometry": {"coordinates":[24.79934331058623,42.13749243763615],"type":"Point"}
+}

--- a/data/144/483/707/3/1444837073.geojson
+++ b/data/144/483/707/3/1444837073.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"16cccd4d552e7f6b36c7ad65173de3a1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"29c80f629d9ec849b39daf52b4d13de0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":-1,
+            "neighbourhood_id":1444837073,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837073,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338968,
     "wof:name":"Kapitan Burago",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,10 +57,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.799343310586234,
-    42.137492437636155,
-    24.799343310586234,
-    42.137492437636155
+    24.79934331058623,
+    42.13749243763615,
+    24.79934331058623,
+    42.13749243763615
 ],
   "geometry": {"coordinates":[24.79934331058623,42.13749243763615],"type":"Point"}
 }

--- a/data/144/483/708/5/1444837085.geojson
+++ b/data/144/483/708/5/1444837085.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837085,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7937070925,42.1373439286,24.7937070925,42.1373439286",
+    "geom:latitude":42.137344,
+    "geom:longitude":24.793707,
+    "iso:country":"BG",
+    "lbl:latitude":42.137344,
+    "lbl:longitude":24.793707,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A8"
+    ],
+    "name:eng_x_preferred":[
+        "\u041e\u0431\u043e\u0440\u0438\u0449\u0435"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"ab29ce79671af43e55edb1c4b737b8e9",
+    "wof:hierarchy":[],
+    "wof:id":1444837085,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Oborishte",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.7937070925404,
+    42.13734392858559,
+    24.7937070925404,
+    42.13734392858559
+],
+  "geometry": {"coordinates":[24.7937070925404,42.13734392858559],"type":"Point"}
+}

--- a/data/144/483/708/5/1444837085.geojson
+++ b/data/144/483/708/5/1444837085.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"ab29ce79671af43e55edb1c4b737b8e9",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837085,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837085,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338971,
     "wof:name":"Oborishte",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/709/1/1444837091.geojson
+++ b/data/144/483/709/1/1444837091.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"0d4a31951701b4c17fb67f7ca7ba2831",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837091,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837091,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338971,
     "wof:name":"Han Asparuh",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/709/1/1444837091.geojson
+++ b/data/144/483/709/1/1444837091.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837091,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7915041038,42.1421596875,24.7915041038,42.1421596875",
+    "geom:latitude":42.14216,
+    "geom:longitude":24.791504,
+    "iso:country":"BG",
+    "lbl:latitude":42.14216,
+    "lbl:longitude":24.791504,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A9"
+    ],
+    "name:eng_x_preferred":[
+        "\u0425\u0430\u043d \u0410\u0441\u043f\u0430\u0440\u0443\u0445"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"0d4a31951701b4c17fb67f7ca7ba2831",
+    "wof:hierarchy":[],
+    "wof:id":1444837091,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Han Asparuh",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.79150410376106,
+    42.14215968746371,
+    24.79150410376106,
+    42.14215968746371
+],
+  "geometry": {"coordinates":[24.79150410376106,42.14215968746371],"type":"Point"}
+}

--- a/data/144/483/710/3/1444837103.geojson
+++ b/data/144/483/710/3/1444837103.geojson
@@ -1,0 +1,55 @@
+{
+  "id": 1444837103,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7857534447,42.1402503996,24.7857534447,42.1402503996",
+    "geom:latitude":42.14025,
+    "geom:longitude":24.785753,
+    "iso:country":"BG",
+    "lbl:latitude":42.14025,
+    "lbl:longitude":24.785753,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A10",
+        "V\"zrazhdane"
+    ],
+    "name:eng_x_preferred":[
+        "\u0412\u044a\u0437\u0440\u0430\u0436\u0434\u0430\u043d\u0435"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"575bd0a36d9da6bb191b128e373150b8",
+    "wof:hierarchy":[],
+    "wof:id":1444837103,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Vuzrazhdane",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.78575344473967,
+    42.140250399568224,
+    24.78575344473967,
+    42.140250399568224
+],
+  "geometry": {"coordinates":[24.78575344473967,42.14025039956822],"type":"Point"}
+}

--- a/data/144/483/710/3/1444837103.geojson
+++ b/data/144/483/710/3/1444837103.geojson
@@ -30,15 +30,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"575bd0a36d9da6bb191b128e373150b8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e9f56e1696c74a7a62eee3b98b3bc3f7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837103,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837103,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338972,
     "wof:name":"Vuzrazhdane",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -47,9 +60,9 @@
 },
   "bbox": [
     24.78575344473967,
-    42.140250399568224,
+    42.14025039956822,
     24.78575344473967,
-    42.140250399568224
+    42.14025039956822
 ],
   "geometry": {"coordinates":[24.78575344473967,42.14025039956822],"type":"Point"}
 }

--- a/data/144/483/710/9/1444837109.geojson
+++ b/data/144/483/710/9/1444837109.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837109,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7885572486,42.1366013781,24.7885572486,42.1366013781",
+    "geom:latitude":42.136601,
+    "geom:longitude":24.788557,
+    "iso:country":"BG",
+    "lbl:latitude":42.136601,
+    "lbl:longitude":24.788557,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A11"
+    ],
+    "name:eng_x_preferred":[
+        "\u0417\u0430\u0445\u0430\u0440\u0438 \u0417\u043e\u0433\u0440\u0430\u0444"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"677c20b3d72942354198f2a3c0cb9f3f",
+    "wof:hierarchy":[],
+    "wof:id":1444837109,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Zahari Zograf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.788557248640643,
+    42.136601378108715,
+    24.788557248640643,
+    42.136601378108715
+],
+  "geometry": {"coordinates":[24.78855724864064,42.13660137810871],"type":"Point"}
+}

--- a/data/144/483/710/9/1444837109.geojson
+++ b/data/144/483/710/9/1444837109.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"677c20b3d72942354198f2a3c0cb9f3f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"96d07828938e8ef99e131893b28259b2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837109,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837109,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338973,
     "wof:name":"Zahari Zograf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,10 +58,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.788557248640643,
-    42.136601378108715,
-    24.788557248640643,
-    42.136601378108715
+    24.78855724864064,
+    42.13660137810871,
+    24.78855724864064,
+    42.13660137810871
 ],
   "geometry": {"coordinates":[24.78855724864064,42.13660137810871],"type":"Point"}
 }

--- a/data/144/483/712/1/1444837121.geojson
+++ b/data/144/483/712/1/1444837121.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"79c8694591841de636d5bb4f116098df",
-    "wof:hierarchy":[],
+    "wof:geomhash":"81cc4bd440c0c5582123441fd2d99e7a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837121,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837121,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338976,
     "wof:name":"Lauta",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.777227592061188,
+    24.77722759206119,
     42.13390690754927,
-    24.777227592061188,
+    24.77722759206119,
     42.13390690754927
 ],
   "geometry": {"coordinates":[24.77722759206119,42.13390690754927],"type":"Point"}

--- a/data/144/483/712/1/1444837121.geojson
+++ b/data/144/483/712/1/1444837121.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837121,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7772275921,42.1339069075,24.7772275921,42.1339069075",
+    "geom:latitude":42.133907,
+    "geom:longitude":24.777228,
+    "iso:country":"BG",
+    "lbl:latitude":42.133907,
+    "lbl:longitude":24.777227,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A12"
+    ],
+    "name:eng_x_preferred":[
+        "\u041b\u0430\u0443\u0442\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"79c8694591841de636d5bb4f116098df",
+    "wof:hierarchy":[],
+    "wof:id":1444837121,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Lauta",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.777227592061188,
+    42.13390690754927,
+    24.777227592061188,
+    42.13390690754927
+],
+  "geometry": {"coordinates":[24.77722759206119,42.13390690754927],"type":"Point"}
+}

--- a/data/144/483/713/3/1444837133.geojson
+++ b/data/144/483/713/3/1444837133.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"3dc6728a2138e42359148a9ac56ad574",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b6fb6d32bc0f18ebf1ed33b281b92738",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837133,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837133,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338976,
     "wof:name":"Olga Skobeleva",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.798399172537945,
+    24.79839917253794,
     42.1444719701622,
-    24.798399172537945,
+    24.79839917253794,
     42.1444719701622
 ],
   "geometry": {"coordinates":[24.79839917253794,42.1444719701622],"type":"Point"}

--- a/data/144/483/713/3/1444837133.geojson
+++ b/data/144/483/713/3/1444837133.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837133,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7983991725,42.1444719702,24.7983991725,42.1444719702",
+    "geom:latitude":42.144472,
+    "geom:longitude":24.798399,
+    "iso:country":"BG",
+    "lbl:latitude":42.144472,
+    "lbl:longitude":24.798399,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "A13"
+    ],
+    "name:eng_x_preferred":[
+        "\u0421\u043a\u043e\u0431\u0435\u043b\u0435\u0432\u0430 \u043c\u0430\u0439\u043a\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"3dc6728a2138e42359148a9ac56ad574",
+    "wof:hierarchy":[],
+    "wof:id":1444837133,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Olga Skobeleva",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.798399172537945,
+    42.1444719701622,
+    24.798399172537945,
+    42.1444719701622
+],
+  "geometry": {"coordinates":[24.79839917253794,42.1444719701622],"type":"Point"}
+}

--- a/data/144/483/714/3/1444837143.geojson
+++ b/data/144/483/714/3/1444837143.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"feca798ccb98bc1ed17b887c907aedaa",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a3b3f19be075560caaaef3b062f104ce",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837143,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837143,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338977,
     "wof:name":"Trakia Industrial Zone",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,10 +55,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.783865168643086,
-    42.120454056498936,
-    24.783865168643086,
-    42.120454056498936
+    24.78386516864309,
+    42.12045405649894,
+    24.78386516864309,
+    42.12045405649894
 ],
   "geometry": {"coordinates":[24.78386516864309,42.12045405649894],"type":"Point"}
 }

--- a/data/144/483/714/3/1444837143.geojson
+++ b/data/144/483/714/3/1444837143.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837143,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7838651686,42.1204540565,24.7838651686,42.1204540565",
+    "geom:latitude":42.120454,
+    "geom:longitude":24.783865,
+    "iso:country":"BG",
+    "lbl:latitude":42.120454,
+    "lbl:longitude":24.783865,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0418\u043d\u0434\u0443\u0441\u0442\u0440\u0438\u0430\u043b\u043d\u0430 \u0437\u043e\u043d\u0430 \u0422\u0440\u0430\u043a\u0438\u044f"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"feca798ccb98bc1ed17b887c907aedaa",
+    "wof:hierarchy":[],
+    "wof:id":1444837143,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Trakia Industrial Zone",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.783865168643086,
+    42.120454056498936,
+    24.783865168643086,
+    42.120454056498936
+],
+  "geometry": {"coordinates":[24.78386516864309,42.12045405649894],"type":"Point"}
+}

--- a/data/144/483/715/5/1444837155.geojson
+++ b/data/144/483/715/5/1444837155.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"a259af5c267e900672de5664eda92919",
-    "wof:hierarchy":[],
+    "wof:geomhash":"806772fbb2979450253c4f3dc42f6a7e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837155,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837155,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338978,
     "wof:name":"Iztochen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -43,9 +56,9 @@
 },
   "bbox": [
     24.78306408181423,
-    42.152871846142084,
+    42.15287184614208,
     24.78306408181423,
-    42.152871846142084
+    42.15287184614208
 ],
   "geometry": {"coordinates":[24.78306408181423,42.15287184614208],"type":"Point"}
 }

--- a/data/144/483/715/5/1444837155.geojson
+++ b/data/144/483/715/5/1444837155.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837155,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7830640818,42.1528718461,24.7830640818,42.1528718461",
+    "geom:latitude":42.152872,
+    "geom:longitude":24.783064,
+    "iso:country":"BG",
+    "lbl:latitude":42.152872,
+    "lbl:longitude":24.783064,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":14.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0418\u0437\u0442\u043e\u0447\u0435\u043d"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"a259af5c267e900672de5664eda92919",
+    "wof:hierarchy":[],
+    "wof:id":1444837155,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Iztochen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.78306408181423,
+    42.152871846142084,
+    24.78306408181423,
+    42.152871846142084
+],
+  "geometry": {"coordinates":[24.78306408181423,42.15287184614208],"type":"Point"}
+}

--- a/data/144/483/716/5/1444837165.geojson
+++ b/data/144/483/716/5/1444837165.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"d002e376741807d6af1f2fa429d0857a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1f16a338c13bca78b9808ef43dadfb17",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837165,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837165,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338981,
     "wof:name":"Sadiiski",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.761949721825257,
+    24.76194972182526,
     42.13284522440028,
-    24.761949721825257,
+    24.76194972182526,
     42.13284522440028
 ],
   "geometry": {"coordinates":[24.76194972182526,42.13284522440028],"type":"Point"}

--- a/data/144/483/716/5/1444837165.geojson
+++ b/data/144/483/716/5/1444837165.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837165,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7619497218,42.1328452244,24.7619497218,42.1328452244",
+    "geom:latitude":42.132845,
+    "geom:longitude":24.76195,
+    "iso:country":"BG",
+    "lbl:latitude":42.132845,
+    "lbl:longitude":24.76195,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0421\u044a\u0434\u0438\u0439\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"d002e376741807d6af1f2fa429d0857a",
+    "wof:hierarchy":[],
+    "wof:id":1444837165,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Sadiiski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.761949721825257,
+    42.13284522440028,
+    24.761949721825257,
+    42.13284522440028
+],
+  "geometry": {"coordinates":[24.76194972182526,42.13284522440028],"type":"Point"}
+}

--- a/data/144/483/717/9/1444837179.geojson
+++ b/data/144/483/717/9/1444837179.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"d7ea1d246371bdb348141106ecd197ff",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8e05bab017d0e0dd425ef91ff26b5312",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837179,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837179,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338981,
     "wof:name":"Komatevo",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.703298721855862,
+    24.70329872185586,
     42.09939906879431,
-    24.703298721855862,
+    24.70329872185586,
     42.09939906879431
 ],
   "geometry": {"coordinates":[24.70329872185586,42.09939906879431],"type":"Point"}

--- a/data/144/483/717/9/1444837179.geojson
+++ b/data/144/483/717/9/1444837179.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837179,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7032987219,42.0993990688,24.7032987219,42.0993990688",
+    "geom:latitude":42.099399,
+    "geom:longitude":24.703299,
+    "iso:country":"BG",
+    "lbl:latitude":42.099399,
+    "lbl:longitude":24.703299,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u043e\u043c\u0430\u0442\u0435\u0432\u043e"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"d7ea1d246371bdb348141106ecd197ff",
+    "wof:hierarchy":[],
+    "wof:id":1444837179,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Komatevo",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.703298721855862,
+    42.09939906879431,
+    24.703298721855862,
+    42.09939906879431
+],
+  "geometry": {"coordinates":[24.70329872185586,42.09939906879431],"type":"Point"}
+}

--- a/data/144/483/719/3/1444837193.geojson
+++ b/data/144/483/719/3/1444837193.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"4562069dc629f7d8ca0c0ead44a1f981",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2c84d3b42758bc9d32164f256dac5a40",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837193,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837193,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338982,
     "wof:name":"Kapana",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.748531517442018,
+    24.74853151744202,
     42.15019927923437,
-    24.748531517442018,
+    24.74853151744202,
     42.15019927923437
 ],
   "geometry": {"coordinates":[24.74853151744202,42.15019927923437],"type":"Point"}

--- a/data/144/483/719/3/1444837193.geojson
+++ b/data/144/483/719/3/1444837193.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837193,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7485315174,42.1501992792,24.7485315174,42.1501992792",
+    "geom:latitude":42.150199,
+    "geom:longitude":24.748532,
+    "iso:country":"BG",
+    "lbl:latitude":42.150199,
+    "lbl:longitude":24.748531,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u0430\u043f\u0430\u043d\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"4562069dc629f7d8ca0c0ead44a1f981",
+    "wof:hierarchy":[],
+    "wof:id":1444837193,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Kapana",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.748531517442018,
+    42.15019927923437,
+    24.748531517442018,
+    42.15019927923437
+],
+  "geometry": {"coordinates":[24.74853151744202,42.15019927923437],"type":"Point"}
+}

--- a/data/144/483/720/7/1444837207.geojson
+++ b/data/144/483/720/7/1444837207.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837207,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7442113706,42.1439416376,24.7442113706,42.1439416376",
+    "geom:latitude":42.143942,
+    "geom:longitude":24.744211,
+    "iso:country":"BG",
+    "lbl:latitude":42.143942,
+    "lbl:longitude":24.744211,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0413\u0440\u043e\u0437\u0434\u043e\u0432 \u043f\u0430\u0437\u0430\u0440"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"085f4a8ae71362baa0394b8ce630de9f",
+    "wof:hierarchy":[],
+    "wof:id":1444837207,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Grozdov pazar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.744211370615,
+    42.14394163755681,
+    24.744211370615,
+    42.14394163755681
+],
+  "geometry": {"coordinates":[24.744211370615,42.14394163755681],"type":"Point"}
+}

--- a/data/144/483/720/7/1444837207.geojson
+++ b/data/144/483/720/7/1444837207.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"085f4a8ae71362baa0394b8ce630de9f",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837207,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837207,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338983,
     "wof:name":"Grozdov pazar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/721/5/1444837215.geojson
+++ b/data/144/483/721/5/1444837215.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"36e4a740a023b1f52421d83034dc97ff",
-    "wof:hierarchy":[],
+    "wof:geomhash":"99704391c240d6200244ae64bc3be54a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837215,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837215,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338986,
     "wof:name":"Juzhen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.739130119888188,
+    24.73913011988819,
     42.11996129596785,
-    24.739130119888188,
+    24.73913011988819,
     42.11996129596785
 ],
   "geometry": {"coordinates":[24.73913011988819,42.11996129596785],"type":"Point"}

--- a/data/144/483/721/5/1444837215.geojson
+++ b/data/144/483/721/5/1444837215.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837215,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7391301199,42.119961296,24.7391301199,42.119961296",
+    "geom:latitude":42.119961,
+    "geom:longitude":24.73913,
+    "iso:country":"BG",
+    "lbl:latitude":42.119961,
+    "lbl:longitude":24.73913,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u042e\u0436\u0435\u043d"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"36e4a740a023b1f52421d83034dc97ff",
+    "wof:hierarchy":[],
+    "wof:id":1444837215,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Juzhen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.739130119888188,
+    42.11996129596785,
+    24.739130119888188,
+    42.11996129596785
+],
+  "geometry": {"coordinates":[24.73913011988819,42.11996129596785],"type":"Point"}
+}

--- a/data/144/483/722/9/1444837229.geojson
+++ b/data/144/483/722/9/1444837229.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837229,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7446077203,42.1275372009,24.7446077203,42.1275372009",
+    "geom:latitude":42.127537,
+    "geom:longitude":24.744608,
+    "iso:country":"BG",
+    "lbl:latitude":42.127537,
+    "lbl:longitude":24.744608,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u044e\u0447\u044e\u043a \u041f\u0430\u0440\u0438\u0436"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"c8b5b586017281552b086cde69d446d6",
+    "wof:hierarchy":[],
+    "wof:id":1444837229,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Kyutchuk Paris",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.744607720251977,
+    42.12753720086025,
+    24.744607720251977,
+    42.12753720086025
+],
+  "geometry": {"coordinates":[24.74460772025198,42.12753720086025],"type":"Point"}
+}

--- a/data/144/483/722/9/1444837229.geojson
+++ b/data/144/483/722/9/1444837229.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"c8b5b586017281552b086cde69d446d6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"47a86e918fac29a74e9cafb9fe520130",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837229,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837229,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338986,
     "wof:name":"Kyutchuk Paris",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.744607720251977,
+    24.74460772025198,
     42.12753720086025,
-    24.744607720251977,
+    24.74460772025198,
     42.12753720086025
 ],
   "geometry": {"coordinates":[24.74460772025198,42.12753720086025],"type":"Point"}

--- a/data/144/483/724/1/1444837241.geojson
+++ b/data/144/483/724/1/1444837241.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"f38cd3dd387b988d0208567d2ca7747e",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837241,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837241,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338987,
     "wof:name":"Vastannicheski",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/724/1/1444837241.geojson
+++ b/data/144/483/724/1/1444837241.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837241,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7344582397,42.1231224287,24.7344582397,42.1231224287",
+    "geom:latitude":42.123122,
+    "geom:longitude":24.734458,
+    "iso:country":"BG",
+    "lbl:latitude":42.123122,
+    "lbl:longitude":24.734458,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0412\u044a\u0441\u0442\u0430\u043d\u0438\u0447\u0435\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"f38cd3dd387b988d0208567d2ca7747e",
+    "wof:hierarchy":[],
+    "wof:id":1444837241,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Vastannicheski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.73445823966941,
+    42.12312242870938,
+    24.73445823966941,
+    42.12312242870938
+],
+  "geometry": {"coordinates":[24.73445823966941,42.12312242870938],"type":"Point"}
+}

--- a/data/144/483/724/7/1444837247.geojson
+++ b/data/144/483/724/7/1444837247.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837247,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7270707968,42.1134956903,24.7270707968,42.1134956903",
+    "geom:latitude":42.113496,
+    "geom:longitude":24.727071,
+    "iso:country":"BG",
+    "lbl:latitude":42.113496,
+    "lbl:longitude":24.727071,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041e\u0441\u0442\u0440\u043e\u043c\u0438\u043b\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"62537d2a1c273c4ef7d4ba5c185680e9",
+    "wof:hierarchy":[],
+    "wof:id":1444837247,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Ostromila",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.72707079678697,
+    42.11349569030785,
+    24.72707079678697,
+    42.11349569030785
+],
+  "geometry": {"coordinates":[24.72707079678697,42.11349569030785],"type":"Point"}
+}

--- a/data/144/483/724/7/1444837247.geojson
+++ b/data/144/483/724/7/1444837247.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"62537d2a1c273c4ef7d4ba5c185680e9",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837247,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837247,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338988,
     "wof:name":"Ostromila",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/726/3/1444837263.geojson
+++ b/data/144/483/726/3/1444837263.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"e5f52f4fb72e57f1e70a470de2290700",
-    "wof:hierarchy":[],
+    "wof:geomhash":"31134ef3f7119970175d6669a7707e44",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837263,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837263,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338991,
     "wof:name":"Industrial Zone-South\t",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.758828167502077,
+    24.75882816750208,
     42.11697626368857,
-    24.758828167502077,
+    24.75882816750208,
     42.11697626368857
 ],
   "geometry": {"coordinates":[24.75882816750208,42.11697626368857],"type":"Point"}

--- a/data/144/483/726/3/1444837263.geojson
+++ b/data/144/483/726/3/1444837263.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837263,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7588281675,42.1169762637,24.7588281675,42.1169762637",
+    "geom:latitude":42.116976,
+    "geom:longitude":24.758828,
+    "iso:country":"BG",
+    "lbl:latitude":42.116976,
+    "lbl:longitude":24.758828,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Industrialna zona jug"
+    ],
+    "name:eng_x_preferred":[
+        "\u0418\u043d\u0434\u0443\u0441\u0442\u0440\u0438\u0430\u043b\u043d\u0430 \u0437\u043e\u043d\u0430 \u044e\u0433"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"e5f52f4fb72e57f1e70a470de2290700",
+    "wof:hierarchy":[],
+    "wof:id":1444837263,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Industrial Zone-South\t",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.758828167502077,
+    42.11697626368857,
+    24.758828167502077,
+    42.11697626368857
+],
+  "geometry": {"coordinates":[24.75882816750208,42.11697626368857],"type":"Point"}
+}

--- a/data/144/483/727/3/1444837273.geojson
+++ b/data/144/483/727/3/1444837273.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"0ae41e81b248f4dae39dcf314d57f1f6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c825a6fa982e010e12c312c99ec105bf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837273,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837273,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338991,
     "wof:name":"Belomorski",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.735882751904313,
+    24.73588275190431,
     42.10895367905951,
-    24.735882751904313,
+    24.73588275190431,
     42.10895367905951
 ],
   "geometry": {"coordinates":[24.73588275190431,42.10895367905951],"type":"Point"}

--- a/data/144/483/727/3/1444837273.geojson
+++ b/data/144/483/727/3/1444837273.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837273,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7358827519,42.1089536791,24.7358827519,42.1089536791",
+    "geom:latitude":42.108954,
+    "geom:longitude":24.735883,
+    "iso:country":"BG",
+    "lbl:latitude":42.108954,
+    "lbl:longitude":24.735883,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0411\u0435\u043b\u043e\u043c\u043e\u0440\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"0ae41e81b248f4dae39dcf314d57f1f6",
+    "wof:hierarchy":[],
+    "wof:id":1444837273,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Belomorski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.735882751904313,
+    42.10895367905951,
+    24.735882751904313,
+    42.10895367905951
+],
+  "geometry": {"coordinates":[24.73588275190431,42.10895367905951],"type":"Point"}
+}

--- a/data/144/483/728/1/1444837281.geojson
+++ b/data/144/483/728/1/1444837281.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"2eb4925ce5fee89e5528e266f3577f18",
-    "wof:hierarchy":[],
+    "wof:geomhash":"40615b70a23b51897cb1dd8af7ed693f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837281,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837281,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338992,
     "wof:name":"Komatevski Vasel",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.716084463134173,
+    24.71608446313417,
     42.12584661671849,
-    24.716084463134173,
+    24.71608446313417,
     42.12584661671849
 ],
   "geometry": {"coordinates":[24.71608446313417,42.12584661671849],"type":"Point"}

--- a/data/144/483/728/1/1444837281.geojson
+++ b/data/144/483/728/1/1444837281.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837281,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7160844631,42.1258466167,24.7160844631,42.1258466167",
+    "geom:latitude":42.125847,
+    "geom:longitude":24.716084,
+    "iso:country":"BG",
+    "lbl:latitude":42.125847,
+    "lbl:longitude":24.716084,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u043e\u043c\u0430\u0442\u0435\u0432\u0441\u043a\u0438 \u0432\u044a\u0437\u0435\u043b"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"2eb4925ce5fee89e5528e266f3577f18",
+    "wof:hierarchy":[],
+    "wof:id":1444837281,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Komatevski Vasel",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.716084463134173,
+    42.12584661671849,
+    24.716084463134173,
+    42.12584661671849
+],
+  "geometry": {"coordinates":[24.71608446313417,42.12584661671849],"type":"Point"}
+}

--- a/data/144/483/729/1/1444837291.geojson
+++ b/data/144/483/729/1/1444837291.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837291,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7470979675,42.1320636119,24.7470979675,42.1320636119",
+    "geom:latitude":42.132064,
+    "geom:longitude":24.747098,
+    "iso:country":"BG",
+    "lbl:latitude":42.132064,
+    "lbl:longitude":24.747098,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0423\u0445\u043e\u0442\u043e"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"4cd9196318dd5659a44330b04756d3c6",
+    "wof:hierarchy":[],
+    "wof:id":1444837291,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Ucho",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.7470979675082,
+    42.13206361191682,
+    24.7470979675082,
+    42.13206361191682
+],
+  "geometry": {"coordinates":[24.7470979675082,42.13206361191682],"type":"Point"}
+}

--- a/data/144/483/729/1/1444837291.geojson
+++ b/data/144/483/729/1/1444837291.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"4cd9196318dd5659a44330b04756d3c6",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837291,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837291,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338993,
     "wof:name":"Ucho",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/730/3/1444837303.geojson
+++ b/data/144/483/730/3/1444837303.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"2d8b4b0bd2262df97df1a6ef3a78d355",
-    "wof:hierarchy":[],
+    "wof:geomhash":"117a2a0e68d42f4c15242f5cfd4da14b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837303,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837303,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338996,
     "wof:name":"Smirnenski",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.715397817280873,
+    24.71539781728087,
     42.13359123805414,
-    24.715397817280873,
+    24.71539781728087,
     42.13359123805414
 ],
   "geometry": {"coordinates":[24.71539781728087,42.13359123805414],"type":"Point"}

--- a/data/144/483/730/3/1444837303.geojson
+++ b/data/144/483/730/3/1444837303.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837303,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7153978173,42.1335912381,24.7153978173,42.1335912381",
+    "geom:latitude":42.133591,
+    "geom:longitude":24.715398,
+    "iso:country":"BG",
+    "lbl:latitude":42.133591,
+    "lbl:longitude":24.715398,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "\u0425\u0440\u0438\u0441\u0442\u043e \u0421\u043c\u0438\u0440\u043d\u0435\u043d\u0441\u043a\u0438"
+    ],
+    "name:eng_x_preferred":[
+        "\u0421\u043c\u0438\u0440\u043d\u0435\u043d\u0441\u043a\u0438"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"2d8b4b0bd2262df97df1a6ef3a78d355",
+    "wof:hierarchy":[],
+    "wof:id":1444837303,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Smirnenski",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.715397817280873,
+    42.13359123805414,
+    24.715397817280873,
+    42.13359123805414
+],
+  "geometry": {"coordinates":[24.71539781728087,42.13359123805414],"type":"Point"}
+}

--- a/data/144/483/731/9/1444837319.geojson
+++ b/data/144/483/731/9/1444837319.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837319,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7266702534,42.1418652815,24.7266702534,42.1418652815",
+    "geom:latitude":42.141865,
+    "geom:longitude":24.72667,
+    "iso:country":"BG",
+    "lbl:latitude":42.141865,
+    "lbl:longitude":24.72667,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "\u0414\u0436\u0435\u043d\u0434\u0435\u043c \u0442\u0435\u043f\u0435"
+    ],
+    "name:eng_x_preferred":[
+        "\u041c\u043b\u0430\u0434\u0435\u0436\u043a\u0438 \u0445\u044a\u043b\u043c"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"c0704096c3ef2333b1861a7ef2cc2b01",
+    "wof:hierarchy":[],
+    "wof:id":1444837319,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Mladezhki Halm",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.726670253372546,
+    42.14186528149754,
+    24.726670253372546,
+    42.14186528149754
+],
+  "geometry": {"coordinates":[24.72667025337255,42.14186528149754],"type":"Point"}
+}

--- a/data/144/483/731/9/1444837319.geojson
+++ b/data/144/483/731/9/1444837319.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"c0704096c3ef2333b1861a7ef2cc2b01",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ef2c05e930673db36423af3b5af4feb4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837319,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837319,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338996,
     "wof:name":"Mladezhki Halm",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.726670253372546,
+    24.72667025337255,
     42.14186528149754,
-    24.726670253372546,
+    24.72667025337255,
     42.14186528149754
 ],
   "geometry": {"coordinates":[24.72667025337255,42.14186528149754],"type":"Point"}

--- a/data/144/483/733/1/1444837331.geojson
+++ b/data/144/483/733/1/1444837331.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"15c0c36b7df0abf2e82fc3f91c28ea48",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837331,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837331,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338997,
     "wof:name":"Proslav",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/733/1/1444837331.geojson
+++ b/data/144/483/733/1/1444837331.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837331,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.68638703,42.1236185348,24.68638703,42.1236185348",
+    "geom:latitude":42.123619,
+    "geom:longitude":24.686387,
+    "iso:country":"BG",
+    "lbl:latitude":42.123618,
+    "lbl:longitude":24.686387,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041f\u0440\u043e\u0441\u043b\u0430\u0432"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"15c0c36b7df0abf2e82fc3f91c28ea48",
+    "wof:hierarchy":[],
+    "wof:id":1444837331,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Proslav",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.68638702997896,
+    42.12361853477912,
+    24.68638702997896,
+    42.12361853477912
+],
+  "geometry": {"coordinates":[24.68638702997896,42.12361853477912],"type":"Point"}
+}

--- a/data/144/483/734/1/1444837341.geojson
+++ b/data/144/483/734/1/1444837341.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837341,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7216348504,42.1460231043,24.7216348504,42.1460231043",
+    "geom:latitude":42.146023,
+    "geom:longitude":24.721635,
+    "iso:country":"BG",
+    "lbl:latitude":42.146023,
+    "lbl:longitude":24.721635,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041e\u0442\u0434\u0438\u0445 \u0438 \u043a\u0443\u043b\u0442\u0443\u0440\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"404ae686b540ef3f52355993629a77ef",
+    "wof:hierarchy":[],
+    "wof:id":1444837341,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Otdih i Kultura",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.721634850448343,
+    42.14602310432054,
+    24.721634850448343,
+    42.14602310432054
+],
+  "geometry": {"coordinates":[24.72163485044834,42.14602310432054],"type":"Point"}
+}

--- a/data/144/483/734/1/1444837341.geojson
+++ b/data/144/483/734/1/1444837341.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"404ae686b540ef3f52355993629a77ef",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ffd085219df1ed90e654c51ee5831762",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837341,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837341,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566338998,
     "wof:name":"Otdih i Kultura",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.721634850448343,
+    24.72163485044834,
     42.14602310432054,
-    24.721634850448343,
+    24.72163485044834,
     42.14602310432054
 ],
   "geometry": {"coordinates":[24.72163485044834,42.14602310432054],"type":"Point"}

--- a/data/144/483/735/3/1444837353.geojson
+++ b/data/144/483/735/3/1444837353.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"4253edaf7fa79d0406570cd191ff7ec0",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837353,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837353,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339001,
     "wof:name":"Smirnenski 1",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/735/3/1444837353.geojson
+++ b/data/144/483/735/3/1444837353.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837353,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7209482046,42.134949114,24.7209482046,42.134949114",
+    "geom:latitude":42.134949,
+    "geom:longitude":24.720948,
+    "iso:country":"BG",
+    "lbl:latitude":42.134949,
+    "lbl:longitude":24.720948,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0421\u043c\u0438\u0440\u043d\u0435\u043d\u0441\u043a\u0438 1"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"4253edaf7fa79d0406570cd191ff7ec0",
+    "wof:hierarchy":[],
+    "wof:id":1444837353,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Smirnenski 1",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.72094820459505,
+    42.13494911395387,
+    24.72094820459505,
+    42.13494911395387
+],
+  "geometry": {"coordinates":[24.72094820459505,42.13494911395387],"type":"Point"}
+}

--- a/data/144/483/736/3/1444837363.geojson
+++ b/data/144/483/736/3/1444837363.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"98a96e218ecd1d6b257813f2bb43f834",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3b0dd767f012d08e03b08ca8d9bd9b9a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837363,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837363,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339001,
     "wof:name":"Smirnenski 2",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.710648516795555,
+    24.71064851679555,
     42.13180900279391,
-    24.710648516795555,
+    24.71064851679555,
     42.13180900279391
 ],
   "geometry": {"coordinates":[24.71064851679555,42.13180900279391],"type":"Point"}

--- a/data/144/483/736/3/1444837363.geojson
+++ b/data/144/483/736/3/1444837363.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837363,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7106485168,42.1318090028,24.7106485168,42.1318090028",
+    "geom:latitude":42.131809,
+    "geom:longitude":24.710649,
+    "iso:country":"BG",
+    "lbl:latitude":42.131809,
+    "lbl:longitude":24.710649,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0421\u043c\u0438\u0440\u043d\u0435\u043d\u0441\u043a\u0438 2"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"98a96e218ecd1d6b257813f2bb43f834",
+    "wof:hierarchy":[],
+    "wof:id":1444837363,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Smirnenski 2",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.710648516795555,
+    42.13180900279391,
+    24.710648516795555,
+    42.13180900279391
+],
+  "geometry": {"coordinates":[24.71064851679555,42.13180900279391],"type":"Point"}
+}

--- a/data/144/483/737/5/1444837375.geojson
+++ b/data/144/483/737/5/1444837375.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"8721502754a0bc03047ee35e57903e73",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837375,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837375,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339002,
     "wof:name":"Western Industrial Zone",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/737/5/1444837375.geojson
+++ b/data/144/483/737/5/1444837375.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837375,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7057847753,42.1370070668,24.7057847753,42.1370070668",
+    "geom:latitude":42.137007,
+    "geom:longitude":24.705785,
+    "iso:country":"BG",
+    "lbl:latitude":42.137007,
+    "lbl:longitude":24.705785,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Zapadna promishlena zona"
+    ],
+    "name:eng_x_preferred":[
+        "\u0417\u0430\u043f\u0430\u0434\u043d\u0430 \u043f\u0440\u043e\u043c\u0438\u0448\u043b\u0435\u043d\u0430 \u0437\u043e\u043d\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"8721502754a0bc03047ee35e57903e73",
+    "wof:hierarchy":[],
+    "wof:id":1444837375,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Western Industrial Zone",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.70578477533467,
+    42.13700706676284,
+    24.70578477533467,
+    42.13700706676284
+],
+  "geometry": {"coordinates":[24.70578477533467,42.13700706676284],"type":"Point"}
+}

--- a/data/144/483/738/7/1444837387.geojson
+++ b/data/144/483/738/7/1444837387.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"e362bc29a5d1f3e2efa5f34e20a5cf06",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837387,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837387,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339003,
     "wof:name":"Maritsa Sever",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/738/7/1444837387.geojson
+++ b/data/144/483/738/7/1444837387.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837387,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7077302719,42.1527471717,24.7077302719,42.1527471717",
+    "geom:latitude":42.152747,
+    "geom:longitude":24.70773,
+    "iso:country":"BG",
+    "lbl:latitude":42.152747,
+    "lbl:longitude":24.70773,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041c\u0430\u0440\u0438\u0446\u0430 \u0441\u0435\u0432\u0435\u0440"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"e362bc29a5d1f3e2efa5f34e20a5cf06",
+    "wof:hierarchy":[],
+    "wof:id":1444837387,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Maritsa Sever",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.70773027191901,
+    42.15274717171003,
+    24.70773027191901,
+    42.15274717171003
+],
+  "geometry": {"coordinates":[24.70773027191901,42.15274717171003],"type":"Point"}
+}

--- a/data/144/483/739/7/1444837397.geojson
+++ b/data/144/483/739/7/1444837397.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837397,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.728501309,42.1594069001,24.728501309,42.1594069001",
+    "geom:latitude":42.159407,
+    "geom:longitude":24.728501,
+    "iso:country":"BG",
+    "lbl:latitude":42.159407,
+    "lbl:longitude":24.728501,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0417\u0430\u0445\u0430\u0440\u043d\u0430 \u0444\u0430\u0431\u0440\u0438\u043a\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"a112eda29b39e6b7c76b92b60240fa9d",
+    "wof:hierarchy":[],
+    "wof:id":1444837397,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Zaharna Fabrika",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.728501308981333,
+    42.15940690009082,
+    24.728501308981333,
+    42.15940690009082
+],
+  "geometry": {"coordinates":[24.72850130898133,42.15940690009082],"type":"Point"}
+}

--- a/data/144/483/739/7/1444837397.geojson
+++ b/data/144/483/739/7/1444837397.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"a112eda29b39e6b7c76b92b60240fa9d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"45760fb83ab3bcebd902b57d4cb3d57c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837397,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837397,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339005,
     "wof:name":"Zaharna Fabrika",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.728501308981333,
+    24.72850130898133,
     42.15940690009082,
-    24.728501308981333,
+    24.72850130898133,
     42.15940690009082
 ],
   "geometry": {"coordinates":[24.72850130898133,42.15940690009082],"type":"Point"}

--- a/data/144/483/740/9/1444837409.geojson
+++ b/data/144/483/740/9/1444837409.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"25aad6d1615744deb9c75f8fb6a1030b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837409,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837409,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339006,
     "wof:name":"Sheker Mahala",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/740/9/1444837409.geojson
+++ b/data/144/483/740/9/1444837409.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837409,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7238664495,42.1628001229,24.7238664495,42.1628001229",
+    "geom:latitude":42.1628,
+    "geom:longitude":24.723866,
+    "iso:country":"BG",
+    "lbl:latitude":42.1628,
+    "lbl:longitude":24.723866,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0428\u0435\u043a\u0435\u0440 \u043c\u0430\u0445\u0430\u043b\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"25aad6d1615744deb9c75f8fb6a1030b",
+    "wof:hierarchy":[],
+    "wof:id":1444837409,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Sheker Mahala",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.72386644947156,
+    42.16280012293677,
+    24.72386644947156,
+    42.16280012293677
+],
+  "geometry": {"coordinates":[24.72386644947156,42.16280012293677],"type":"Point"}
+}

--- a/data/144/483/742/3/1444837423.geojson
+++ b/data/144/483/742/3/1444837423.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"218a00e80ee25326864374dccdcfd24f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"323339997b3cc20b55eab233c8756f8c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837423,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837423,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339007,
     "wof:name":"Filipovo",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,10 +55,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.737198823123133,
-    42.164157361067126,
-    24.737198823123133,
-    42.164157361067126
+    24.73719882312313,
+    42.16415736106713,
+    24.73719882312313,
+    42.16415736106713
 ],
   "geometry": {"coordinates":[24.73719882312313,42.16415736106713],"type":"Point"}
 }

--- a/data/144/483/742/3/1444837423.geojson
+++ b/data/144/483/742/3/1444837423.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837423,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7371988231,42.1641573611,24.7371988231,42.1641573611",
+    "geom:latitude":42.164157,
+    "geom:longitude":24.737199,
+    "iso:country":"BG",
+    "lbl:latitude":42.164157,
+    "lbl:longitude":24.737199,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0424\u0438\u043b\u0438\u043f\u043e\u0432\u043e"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"218a00e80ee25326864374dccdcfd24f",
+    "wof:hierarchy":[],
+    "wof:id":1444837423,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Filipovo",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.737198823123133,
+    42.164157361067126,
+    24.737198823123133,
+    42.164157361067126
+],
+  "geometry": {"coordinates":[24.73719882312313,42.16415736106713],"type":"Point"}
+}

--- a/data/144/483/743/3/1444837433.geojson
+++ b/data/144/483/743/3/1444837433.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"1f5d7a36c5c13ec657081f07d7cefa94",
-    "wof:hierarchy":[],
+    "wof:geomhash":"88cb858154bd4e2f33f48c240c1975d3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837433,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837433,
-    "wof:lastmodified":1566333622,
+    "wof:lastmodified":1566339008,
     "wof:name":"Industrial Zone-North",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -46,9 +59,9 @@
 },
   "bbox": [
     24.73794268946421,
-    42.171112749510726,
+    42.17111274951073,
     24.73794268946421,
-    42.171112749510726
+    42.17111274951073
 ],
   "geometry": {"coordinates":[24.73794268946421,42.17111274951073],"type":"Point"}
 }

--- a/data/144/483/743/3/1444837433.geojson
+++ b/data/144/483/743/3/1444837433.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837433,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7379426895,42.1711127495,24.7379426895,42.1711127495",
+    "geom:latitude":42.171113,
+    "geom:longitude":24.737943,
+    "iso:country":"BG",
+    "lbl:latitude":42.171113,
+    "lbl:longitude":24.737943,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:bul_x_variant":[
+        "Industrialna zona sever"
+    ],
+    "name:eng_x_preferred":[
+        "\u0418\u043d\u0434\u0443\u0441\u0442\u0440\u0438\u0430\u043b\u043d\u0430 \u0437\u043e\u043d\u0430 \u0441\u0435\u0432\u0435\u0440"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"1f5d7a36c5c13ec657081f07d7cefa94",
+    "wof:hierarchy":[],
+    "wof:id":1444837433,
+    "wof:lastmodified":1566333622,
+    "wof:name":"Industrial Zone-North",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.73794268946421,
+    42.171112749510726,
+    24.73794268946421,
+    42.171112749510726
+],
+  "geometry": {"coordinates":[24.73794268946421,42.17111274951073],"type":"Point"}
+}

--- a/data/144/483/744/5/1444837445.geojson
+++ b/data/144/483/744/5/1444837445.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837445,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7545366309,42.1613580255,24.7545366309,42.1613580255",
+    "geom:latitude":42.161358,
+    "geom:longitude":24.754537,
+    "iso:country":"BG",
+    "lbl:latitude":42.161358,
+    "lbl:longitude":24.754537,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0413\u0430\u0433\u0430\u0440\u0438\u043d"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"28f616370ef1ea1db5b4d1c2b1804d38",
+    "wof:hierarchy":[],
+    "wof:id":1444837445,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Gagarin",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.754536630918953,
+    42.161358025521864,
+    24.754536630918953,
+    42.161358025521864
+],
+  "geometry": {"coordinates":[24.75453663091895,42.16135802552186],"type":"Point"}
+}

--- a/data/144/483/744/5/1444837445.geojson
+++ b/data/144/483/744/5/1444837445.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"28f616370ef1ea1db5b4d1c2b1804d38",
-    "wof:hierarchy":[],
+    "wof:geomhash":"066683bdbc49ddfabfccccf73e8336a7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837445,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837445,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339010,
     "wof:name":"Gagarin",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,10 +55,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.754536630918953,
-    42.161358025521864,
-    24.754536630918953,
-    42.161358025521864
+    24.75453663091895,
+    42.16135802552186,
+    24.75453663091895,
+    42.16135802552186
 ],
   "geometry": {"coordinates":[24.75453663091895,42.16135802552186],"type":"Point"}
 }

--- a/data/144/483/745/7/1444837457.geojson
+++ b/data/144/483/745/7/1444837457.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837457,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.742463108,42.1564376772,24.742463108,42.1564376772",
+    "geom:latitude":42.156438,
+    "geom:longitude":24.742463,
+    "iso:country":"BG",
+    "lbl:latitude":42.156438,
+    "lbl:longitude":24.742463,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u041a\u044a\u0440\u0448\u0438\u044f\u043a\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"75a9923c6e227a3ce22911b6584799c6",
+    "wof:hierarchy":[],
+    "wof:id":1444837457,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Karshiaka",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.74246310799843,
+    42.156437677230755,
+    24.74246310799843,
+    42.156437677230755
+],
+  "geometry": {"coordinates":[24.74246310799843,42.15643767723076],"type":"Point"}
+}

--- a/data/144/483/745/7/1444837457.geojson
+++ b/data/144/483/745/7/1444837457.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"75a9923c6e227a3ce22911b6584799c6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eb29c99b7e2ff82e6b7927ebc1fdfdcc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837457,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837457,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339011,
     "wof:name":"Karshiaka",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -43,9 +56,9 @@
 },
   "bbox": [
     24.74246310799843,
-    42.156437677230755,
+    42.15643767723076,
     24.74246310799843,
-    42.156437677230755
+    42.15643767723076
 ],
   "geometry": {"coordinates":[24.74246310799843,42.15643767723076],"type":"Point"}
 }

--- a/data/144/483/746/7/1444837467.geojson
+++ b/data/144/483/746/7/1444837467.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
     "wof:geomhash":"8c0c67ed339363f0c0708899b56aa417",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837467,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837467,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339012,
     "wof:name":"Harman Mahala",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],

--- a/data/144/483/746/7/1444837467.geojson
+++ b/data/144/483/746/7/1444837467.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837467,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7464685421,42.1672534516,24.7464685421,42.1672534516",
+    "geom:latitude":42.167253,
+    "geom:longitude":24.746469,
+    "iso:country":"BG",
+    "lbl:latitude":42.167253,
+    "lbl:longitude":24.746468,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0425\u0430\u0440\u043c\u0430\u043d \u043c\u0430\u0445\u0430\u043b\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"8c0c67ed339363f0c0708899b56aa417",
+    "wof:hierarchy":[],
+    "wof:id":1444837467,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Harman Mahala",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.74646854214268,
+    42.16725345158317,
+    24.74646854214268,
+    42.16725345158317
+],
+  "geometry": {"coordinates":[24.74646854214268,42.16725345158317],"type":"Point"}
+}

--- a/data/144/483/748/1/1444837481.geojson
+++ b/data/144/483/748/1/1444837481.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837481,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7385721148,42.174929406,24.7385721148,42.174929406",
+    "geom:latitude":42.174929,
+    "geom:longitude":24.738572,
+    "iso:country":"BG",
+    "lbl:latitude":42.174929,
+    "lbl:longitude":24.738572,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0413\u0430\u0433\u0430\u043d\u0438\u0446\u0430"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"d703c798fee001f013dac807362346ac",
+    "wof:hierarchy":[],
+    "wof:id":1444837481,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Gaganitsa",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.738572114829733,
+    42.17492940598044,
+    24.738572114829733,
+    42.17492940598044
+],
+  "geometry": {"coordinates":[24.73857211482973,42.17492940598044],"type":"Point"}
+}

--- a/data/144/483/748/1/1444837481.geojson
+++ b/data/144/483/748/1/1444837481.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"d703c798fee001f013dac807362346ac",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9c9998aeed26575d07ad3812b897e88a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837481,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837481,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339012,
     "wof:name":"Gaganitsa",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.738572114829733,
+    24.73857211482973,
     42.17492940598044,
-    24.738572114829733,
+    24.73857211482973,
     42.17492940598044
 ],
   "geometry": {"coordinates":[24.73857211482973,42.17492940598044],"type":"Point"}

--- a/data/144/483/748/5/1444837485.geojson
+++ b/data/144/483/748/5/1444837485.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"89a6d645c3554fbd6c1c8b5c9f0de702",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ffd07b81c0ac0deea049d5fc208c201c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837485,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837485,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339015,
     "wof:name":"Severen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,10 +55,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.741204257267377,
-    42.162842537069054,
-    24.741204257267377,
-    42.162842537069054
+    24.74120425726738,
+    42.16284253706905,
+    24.74120425726738,
+    42.16284253706905
 ],
   "geometry": {"coordinates":[24.74120425726738,42.16284253706905],"type":"Point"}
 }

--- a/data/144/483/748/5/1444837485.geojson
+++ b/data/144/483/748/5/1444837485.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837485,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.7412042573,42.1628425371,24.7412042573,42.1628425371",
+    "geom:latitude":42.162843,
+    "geom:longitude":24.741204,
+    "iso:country":"BG",
+    "lbl:latitude":42.162842,
+    "lbl:longitude":24.741204,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0421\u0435\u0432\u0435\u0440\u0435\u043d"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"89a6d645c3554fbd6c1c8b5c9f0de702",
+    "wof:hierarchy":[],
+    "wof:id":1444837485,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Severen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.741204257267377,
+    42.162842537069054,
+    24.741204257267377,
+    42.162842537069054
+],
+  "geometry": {"coordinates":[24.74120425726738,42.16284253706905],"type":"Point"}
+}

--- a/data/144/483/750/1/1444837501.geojson
+++ b/data/144/483/750/1/1444837501.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101748889,
+        85633001,
+        85681779
+    ],
     "wof:breaches":[],
     "wof:country":"BG",
-    "wof:geomhash":"5bd4a4ff9d7f404dcabfbba656d64385",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cbc1a817eb8f7eb6b2c2157e0234e02b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633001,
+            "locality_id":101748889,
+            "neighbourhood_id":1444837501,
+            "region_id":85681779
+        }
+    ],
     "wof:id":1444837501,
-    "wof:lastmodified":1566333623,
+    "wof:lastmodified":1566339016,
     "wof:name":"Sapaden",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748889,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bg",
     "wof:superseded_by":[],
@@ -42,9 +55,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    24.699490521679415,
+    24.69949052167942,
     42.13382462934621,
-    24.699490521679415,
+    24.69949052167942,
     42.13382462934621
 ],
   "geometry": {"coordinates":[24.69949052167942,42.13382462934621],"type":"Point"}

--- a/data/144/483/750/1/1444837501.geojson
+++ b/data/144/483/750/1/1444837501.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837501,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"24.6994905217,42.1338246293,24.6994905217,42.1338246293",
+    "geom:latitude":42.133825,
+    "geom:longitude":24.699491,
+    "iso:country":"BG",
+    "lbl:latitude":42.133825,
+    "lbl:longitude":24.69949,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "\u0417\u0430\u043f\u0430\u0434\u0435\u043d"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"BG",
+    "wof:geomhash":"5bd4a4ff9d7f404dcabfbba656d64385",
+    "wof:hierarchy":[],
+    "wof:id":1444837501,
+    "wof:lastmodified":1566333623,
+    "wof:name":"Sapaden",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-bg",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    24.699490521679415,
+    42.13382462934621,
+    24.699490521679415,
+    42.13382462934621
+],
+  "geometry": {"coordinates":[24.69949052167942,42.13382462934621],"type":"Point"}
+}


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 