### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/748/873/101748873.geojson
+++ b/data/101/748/873/101748873.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Kardzhali"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6232be64aa231a3a055635ef9e9fffb",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614114,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041a\u044a\u0440\u0434\u0436\u0430\u043b\u0438",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/748/875/101748875.geojson
+++ b/data/101/748/875/101748875.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Blagoevgrad"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6692dde0a7e3c1aa3b7bef213f769215",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614115,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0411\u043b\u0430\u0433\u043e\u0435\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/748/877/101748877.geojson
+++ b/data/101/748/877/101748877.geojson
@@ -356,6 +356,9 @@
         "wk:page":"Kyustendil"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39f0cccaee8a95f72c85d179eae63486",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041a\u044e\u0441\u0442\u0435\u043d\u0434\u0438\u043b",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/748/881/101748881.geojson
+++ b/data/101/748/881/101748881.geojson
@@ -359,6 +359,9 @@
         "wk:page":"Haskovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10288fd0df6b51e24201b1e2266ff81b",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614115,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0425\u0430\u0441\u043a\u043e\u0432\u043e",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/748/883/101748883.geojson
+++ b/data/101/748/883/101748883.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Pazardzhik"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f4add9ad4466d1b125705c834d0b223",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614117,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041f\u0430\u0437\u0430\u0440\u0434\u0436\u0438\u043a",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/748/885/101748885.geojson
+++ b/data/101/748/885/101748885.geojson
@@ -317,6 +317,9 @@
         "qs_pg:id":1028724
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae3152adc79817fdd3793e073ba586c5",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614117,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041f\u0435\u0440\u043d\u0438\u043a",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/748/887/101748887.geojson
+++ b/data/101/748/887/101748887.geojson
@@ -724,6 +724,9 @@
         "qs_pg:id":491815
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e818aeaa0d92b5c1bab5fef7bfd6de9",
     "wof:hierarchy":[
         {
@@ -737,7 +740,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578084065,
+    "wof:lastmodified":1582345673,
     "wof:megacity":1,
     "wof:name":"Sofia",
     "wof:parent_id":85681771,

--- a/data/101/748/889/101748889.geojson
+++ b/data/101/748/889/101748889.geojson
@@ -491,6 +491,9 @@
         "qs_pg:id":1028723
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b9942a6ab6fbe450c79b4ab8b939981",
     "wof:hierarchy":[
         {
@@ -504,7 +507,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614114,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041f\u043b\u043e\u0432\u0434\u0438\u0432",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/748/891/101748891.geojson
+++ b/data/101/748/891/101748891.geojson
@@ -267,6 +267,9 @@
         "wd:id":"Q191871"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40672ec9e687c6860f7243df310a5659",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614117,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0410\u0441\u0435\u043d\u043e\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/748/893/101748893.geojson
+++ b/data/101/748/893/101748893.geojson
@@ -264,6 +264,9 @@
         "wk:page":"Kazanlak"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a43a00117141c4c0dedf37fe6acffda",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614115,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041a\u0430\u0437\u0430\u043d\u043b\u044a\u043a",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/748/895/101748895.geojson
+++ b/data/101/748/895/101748895.geojson
@@ -385,6 +385,9 @@
         "wk:page":"Stara Zagora"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6011fad71912caf67709f058720ecdbf",
     "wof:hierarchy":[
         {
@@ -398,7 +401,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614115,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0421\u0442\u0430\u0440\u0430 \u0417\u0430\u0433\u043e\u0440\u0430",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/748/899/101748899.geojson
+++ b/data/101/748/899/101748899.geojson
@@ -256,6 +256,9 @@
         "wk:page":"Yambol"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"51c238c45bb4a3bc593a9b2d13edb5aa",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614118,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u042f\u043c\u0431\u043e\u043b",
     "wof:parent_id":85681793,
     "wof:placetype":"locality",

--- a/data/101/748/901/101748901.geojson
+++ b/data/101/748/901/101748901.geojson
@@ -282,6 +282,9 @@
         "qs_pg:id":404138
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9ce6f6e3c2d427a80a7062d948a2632",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614113,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0413\u0430\u0431\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681797,
     "wof:placetype":"locality",

--- a/data/101/748/903/101748903.geojson
+++ b/data/101/748/903/101748903.geojson
@@ -400,6 +400,9 @@
         "wk:page":"Sliven"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ea06cf2390d6919c148cd09c989c49f",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0421\u043b\u0438\u0432\u0435\u043d",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/748/905/101748905.geojson
+++ b/data/101/748/905/101748905.geojson
@@ -441,6 +441,9 @@
         "qs_pg:id":1084625
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c247419835275877a9b70f37f6eec499",
     "wof:hierarchy":[
         {
@@ -454,7 +457,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0411\u0443\u0440\u0433\u0430\u0441",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/748/907/101748907.geojson
+++ b/data/101/748/907/101748907.geojson
@@ -352,6 +352,9 @@
         "wk:page":"Vratsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a0845d12ecfb9c33e5ede2ac14a269f",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614113,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0412\u0440\u0430\u0446\u0430",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/748/909/101748909.geojson
+++ b/data/101/748/909/101748909.geojson
@@ -353,6 +353,9 @@
         "wk:page":"Montana, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ed4fe70f34d03ee40c0b2f93eac0dcd",
     "wof:hierarchy":[
         {
@@ -366,7 +369,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614113,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041c\u043e\u043d\u0442\u0430\u043d\u0430",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/748/911/101748911.geojson
+++ b/data/101/748/911/101748911.geojson
@@ -271,6 +271,9 @@
         "qs_pg:id":1219047
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89d6d68ba0bfa27fa261022ac1f2c2c8",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614118,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u043e \u0422\u044a\u0440\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/748/913/101748913.geojson
+++ b/data/101/748/913/101748913.geojson
@@ -387,6 +387,9 @@
         "wk:page":"Pleven"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ccc176dc120330e891b34c64849c434",
     "wof:hierarchy":[
         {
@@ -400,7 +403,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u041f\u043b\u0435\u0432\u0435\u043d",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/748/917/101748917.geojson
+++ b/data/101/748/917/101748917.geojson
@@ -279,6 +279,9 @@
         "qs_pg:id":907567
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c358d2c1dc2e410afe837f622b3730e9",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614119,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0412\u0438\u0434\u0438\u043d",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/748/919/101748919.geojson
+++ b/data/101/748/919/101748919.geojson
@@ -462,6 +462,9 @@
         "wk:page":"Varna"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04dacb4721fab9757ed58e360ed039a5",
     "wof:hierarchy":[
         {
@@ -475,7 +478,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614118,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0412\u0430\u0440\u043d\u0430",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/748/921/101748921.geojson
+++ b/data/101/748/921/101748921.geojson
@@ -218,6 +218,9 @@
         "qs_pg:id":1167312
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"28fa599b58f107185224e4d1212d75b7",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614118,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0428\u0443\u043c\u0435\u043d",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/748/923/101748923.geojson
+++ b/data/101/748/923/101748923.geojson
@@ -425,6 +425,9 @@
         "qs_pg:id":1028710
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b330f41286918b772642bd45e8e630eb",
     "wof:hierarchy":[
         {
@@ -438,7 +441,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0420\u0443\u0441\u0435",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/748/925/101748925.geojson
+++ b/data/101/748/925/101748925.geojson
@@ -395,6 +395,9 @@
         "wk:page":"Dobrich"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f8f88f7297d0f7eb772b9c6343cd795",
     "wof:hierarchy":[
         {
@@ -408,7 +411,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614116,
+    "wof:lastmodified":1582345673,
     "wof:name":"\u0414\u043e\u0431\u0440\u0438\u0447",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/794/139/101794139.geojson
+++ b/data/101/794/139/101794139.geojson
@@ -125,6 +125,9 @@
         "wd:id":"Q133961"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"53091de1775efcdd2383e4a7a3c1c51e",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101794139,
-    "wof:lastmodified":1566614120,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0428\u0438\u043f\u043a\u0430",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/794/145/101794145.geojson
+++ b/data/101/794/145/101794145.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Malko Tarnovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f804e0b60ad3cb2a16c1cf9c74a94992",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614119,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u041c\u0430\u043b\u043a\u043e \u0422\u044a\u0440\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/794/147/101794147.geojson
+++ b/data/101/794/147/101794147.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Kubrat Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a952a4b34ad993d28446a37f620133d3",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614120,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u041a\u0443\u0431\u0440\u0430\u0442",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/794/507/101794507.geojson
+++ b/data/101/794/507/101794507.geojson
@@ -88,6 +88,9 @@
         "wk:page":"German, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"405ade4a05fb239636487167fd704f45",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101794507,
-    "wof:lastmodified":1566614120,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0413\u0435\u0440\u043c\u0430\u043d",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/795/125/101795125.geojson
+++ b/data/101/795/125/101795125.geojson
@@ -251,6 +251,9 @@
         "wk:page":"Silistra"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cfc727c96096e6840e68700a0822071d",
     "wof:hierarchy":[
         {
@@ -264,7 +267,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614121,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0421\u0438\u043b\u0438\u0441\u0442\u0440\u0430",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/155/101796155.geojson
+++ b/data/101/796/155/101796155.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Kozloduy"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18b9e1e90e8817e2e78b89f6db0c98b7",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614101,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u043e\u0437\u043b\u043e\u0434\u0443\u0439",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/796/159/101796159.geojson
+++ b/data/101/796/159/101796159.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Novae"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac18acdb1675d360b945cdf0608b99fb",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614091,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0432\u0438\u0449\u043e\u0432",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/796/161/101796161.geojson
+++ b/data/101/796/161/101796161.geojson
@@ -144,6 +144,9 @@
         "wd:id":"Q405236"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac963f90eacde2a3c72ee1d7d528b19f",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614092,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u0435\u043b\u0435\u043d\u0435",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/796/163/101796163.geojson
+++ b/data/101/796/163/101796163.geojson
@@ -128,6 +128,9 @@
         "wd:id":"Q407213"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09ce1a3471fcd750fec95c43f9d0d091",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614101,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0413\u0443\u043b\u044f\u043d\u0446\u0438",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/796/167/101796167.geojson
+++ b/data/101/796/167/101796167.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Opaka"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"807e68817bae1c86549e84583f85c176",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614093,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041e\u043f\u0430\u043a\u0430",
     "wof:parent_id":85681839,
     "wof:placetype":"locality",

--- a/data/101/796/169/101796169.geojson
+++ b/data/101/796/169/101796169.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Novo Selo Municipality, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0abd5bf23df2414b7f137d1da9f8a6cd",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614093,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041d\u043e\u0432\u043e \u0441\u0435\u043b\u043e",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/796/171/101796171.geojson
+++ b/data/101/796/171/101796171.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Bregovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d58570f1bfed3439f7c3b9cfc37acafe",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614108,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0411\u0440\u0435\u0433\u043e\u0432\u043e",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/796/173/101796173.geojson
+++ b/data/101/796/173/101796173.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Kula Municipality, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c10b1026a023dca8927b4ad06dfd730f",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0443\u043b\u0430",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/796/177/101796177.geojson
+++ b/data/101/796/177/101796177.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Suvorovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1d6d9b13a76e842a34cadc46e005c20",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614106,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0421\u0443\u0432\u043e\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/179/101796179.geojson
+++ b/data/101/796/179/101796179.geojson
@@ -126,6 +126,9 @@
         "wd:id":"Q2609648"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0ffc656a02ed8a09dcb048f97a495fb",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614106,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0412\u0435\u0442\u0440\u0438\u043d\u043e",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/181/101796181.geojson
+++ b/data/101/796/181/101796181.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Aksakovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1895fa7770fe5e42c3a84d319291998",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614099,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0410\u043a\u0441\u0430\u043a\u043e\u0432\u043e",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/185/101796185.geojson
+++ b/data/101/796/185/101796185.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Devnya Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4ec5059873761bb30a9a7316d2ea92e",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614108,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0414\u0435\u0432\u043d\u044f",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/187/101796187.geojson
+++ b/data/101/796/187/101796187.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Beloslav Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09cf01958ad2d634abc8ba54abdcf3fe",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0411\u0435\u043b\u043e\u0441\u043b\u0430\u0432",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/189/101796189.geojson
+++ b/data/101/796/189/101796189.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Provadia"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aac3c80307a9b1876fdf80a8e4a23010",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041f\u0440\u043e\u0432\u0430\u0434\u0438\u044f",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/191/101796191.geojson
+++ b/data/101/796/191/101796191.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Avren, Varna Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d9ce8c6264bbb8689c615eec7ed403f",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614100,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0410\u0432\u0440\u0435\u043d",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/796/193/101796193.geojson
+++ b/data/101/796/193/101796193.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Kaolinovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"22af9a56a0efa7d8fbafada378c7a399",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614093,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041a\u0430\u043e\u043b\u0438\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/796/197/101796197.geojson
+++ b/data/101/796/197/101796197.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q2657344"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3e4181235a11a0b818323c87296ee1d",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614101,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0412\u0435\u043d\u0435\u0446",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/796/203/101796203.geojson
+++ b/data/101/796/203/101796203.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q4322590"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccbabcb243d518d3b40c87e339183ae9",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614096,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041d\u043e\u0432\u0438 \u043f\u0430\u0437\u0430\u0440",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/796/217/101796217.geojson
+++ b/data/101/796/217/101796217.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Zavet Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3b5b04072594ab586b49eceba508f33",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0417\u0430\u0432\u0435\u0442",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/221/101796221.geojson
+++ b/data/101/796/221/101796221.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Isperih"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d93db34d3dada66945b4cd62a19919d0",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0418\u0441\u043f\u0435\u0440\u0438\u0445",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/223/101796223.geojson
+++ b/data/101/796/223/101796223.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q407121"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b56518ffd619db6c9561fa4281db457b",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614103,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0426\u0430\u0440 \u041a\u0430\u043b\u043e\u044f\u043d",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/225/101796225.geojson
+++ b/data/101/796/225/101796225.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Razgrad"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ae8cd876a33facf0ba63ddb0c89a0c3",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614103,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0420\u0430\u0437\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/227/101796227.geojson
+++ b/data/101/796/227/101796227.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Samuil Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad88ca9e92a9c0f5a4d821b94abe704e",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0430\u043c\u0443\u0438\u043b",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/229/101796229.geojson
+++ b/data/101/796/229/101796229.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Loznitsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70f135bf9b0b3594ac1894536bfda94d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041b\u043e\u0437\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/796/231/101796231.geojson
+++ b/data/101/796/231/101796231.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Slivo Pole"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc1b4e6ac3b72f512e736bea9555e97a",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614104,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0421\u043b\u0438\u0432\u043e \u043f\u043e\u043b\u0435",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/245/101796245.geojson
+++ b/data/101/796/245/101796245.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q404746"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2939a5c3c9829ea69f048def26fcd13",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0412\u0435\u0442\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/247/101796247.geojson
+++ b/data/101/796/247/101796247.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Ivanovo, Ruse Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b778995361505c317a28f172c6514620",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614103,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0418\u0432\u0430\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/249/101796249.geojson
+++ b/data/101/796/249/101796249.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Dve Mogili"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c99669fec653722570ca20890f85207",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614103,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0414\u0432\u0435 \u043c\u043e\u0433\u0438\u043b\u0438",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/251/101796251.geojson
+++ b/data/101/796/251/101796251.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Tsenovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64706f44fa5deba28d0bc5367fe62b53",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614097,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0426\u0435\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/253/101796253.geojson
+++ b/data/101/796/253/101796253.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Borovo, Ruse Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e48324b8ef5b34bd9038133cc987d3a",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614104,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0411\u043e\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/796/259/101796259.geojson
+++ b/data/101/796/259/101796259.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Krushari"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"112b34430bc462f6a0976bbfa9159858",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614095,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0440\u0443\u0448\u0430\u0440\u0438",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/261/101796261.geojson
+++ b/data/101/796/261/101796261.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Tervel Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e79b2f8cddff86f74ca2ae41c049f40",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614096,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0422\u0435\u0440\u0432\u0435\u043b",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/263/101796263.geojson
+++ b/data/101/796/263/101796263.geojson
@@ -131,6 +131,9 @@
         "wk:page":"General Toshevo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6abc2c1baeb2c27ef6609bd59352254",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614105,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0413\u0435\u043d\u0435\u0440\u0430\u043b \u0422\u043e\u0448\u0435\u0432\u043e",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/265/101796265.geojson
+++ b/data/101/796/265/101796265.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Shabla Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa0f1f2326a2c4e316043c2f0c723a80",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614104,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0428\u0430\u0431\u043b\u0430",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/269/101796269.geojson
+++ b/data/101/796/269/101796269.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":1167303
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b42b75303d408bd9e1d7b7ed6ad8613",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614097,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041b\u043e\u0437\u0435\u043d\u0435\u0446",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/283/101796283.geojson
+++ b/data/101/796/283/101796283.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Kavarna Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f815528e9f2ca3ac1faf6fbc64ec507d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614102,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0430\u0432\u0430\u0440\u043d\u0430",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/285/101796285.geojson
+++ b/data/101/796/285/101796285.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Balchik"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f7de8ba977a8e44bc6b87c7089bc0d5c",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614103,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0411\u0430\u043b\u0447\u0438\u043a",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/796/287/101796287.geojson
+++ b/data/101/796/287/101796287.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Tutrakan"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b830092a5e67a50b99442be0faba71c0",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0422\u0443\u0442\u0440\u0430\u043a\u0430\u043d",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/289/101796289.geojson
+++ b/data/101/796/289/101796289.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Sitovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9744ad6ea7bee95e85aed87cc5cf6d93",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614094,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0438\u0442\u043e\u0432\u043e",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/293/101796293.geojson
+++ b/data/101/796/293/101796293.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q2346358"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6310ce20a41db724d1b2d5252cb18b35",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614097,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0430\u0439\u043d\u0430\u0440\u0434\u0436\u0430",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/295/101796295.geojson
+++ b/data/101/796/295/101796295.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Alfatar"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71286c3e878d252acce7a2d59f770177",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614096,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0410\u043b\u0444\u0430\u0442\u0430\u0440",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/297/101796297.geojson
+++ b/data/101/796/297/101796297.geojson
@@ -134,6 +134,9 @@
         "wd:id":"Q405481"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"255dd9492dda9ca0abbb108dd3b8b33b",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614104,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0413\u043b\u0430\u0432\u0438\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/299/101796299.geojson
+++ b/data/101/796/299/101796299.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Dulovo, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7aacee4cb6abb00a7ef97ce5af0d569f",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614105,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0414\u0443\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681871,
     "wof:placetype":"locality",

--- a/data/101/796/851/101796851.geojson
+++ b/data/101/796/851/101796851.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Boynitsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c63ae13489702b2e295866de22182dfb",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614096,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0411\u043e\u0439\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/796/915/101796915.geojson
+++ b/data/101/796/915/101796915.geojson
@@ -137,6 +137,9 @@
         "wd:id":"Q407207"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0da5e147f484d3cf9f2e5729a1966243",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101796915,
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0413\u0443\u0440\u043a\u043e\u0432\u043e",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/796/917/101796917.geojson
+++ b/data/101/796/917/101796917.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Nikolaevo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1524b50e23a31187344dad839ec41421",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614107,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041d\u0438\u043a\u043e\u043b\u0430\u0435\u0432\u043e",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/796/919/101796919.geojson
+++ b/data/101/796/919/101796919.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q405420"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2954f46fb29e249a6be148a8f3ea0d7",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614107,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0413\u043e\u0434\u0435\u0447",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/796/923/101796923.geojson
+++ b/data/101/796/923/101796923.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q7119063"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f112b2a6de65196d59b8569ed1e7de8a",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614099,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0411\u043e\u0442\u0435\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/796/925/101796925.geojson
+++ b/data/101/796/925/101796925.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Pravets"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30c34f395f691ba09b7ae3fc18f8adf5",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614100,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041f\u0440\u0430\u0432\u0435\u0446",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/796/927/101796927.geojson
+++ b/data/101/796/927/101796927.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Straldzha"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11e5cc3a917a6813603cbfa5c5a3c1ae",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614105,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0421\u0442\u0440\u0430\u043b\u0434\u0436\u0430",
     "wof:parent_id":85681793,
     "wof:placetype":"locality",

--- a/data/101/796/937/101796937.geojson
+++ b/data/101/796/937/101796937.geojson
@@ -188,6 +188,9 @@
         "wd:id":"Q326312"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce21024ff5b58a4aced21750fe88b74d",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614092,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0435\u0432\u043b\u0438\u0435\u0432\u043e",
     "wof:parent_id":85681797,
     "wof:placetype":"locality",

--- a/data/101/796/941/101796941.geojson
+++ b/data/101/796/941/101796941.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Tryavna"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"298347c7199a5e13319fb57709b32a11",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0422\u0440\u044f\u0432\u043d\u0430",
     "wof:parent_id":85681797,
     "wof:placetype":"locality",

--- a/data/101/796/943/101796943.geojson
+++ b/data/101/796/943/101796943.geojson
@@ -147,6 +147,9 @@
         "wd:id":"Q404822"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71516f5373eb517da9e38ec16da74cc7",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614108,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041a\u043e\u0442\u0435\u043b",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/796/945/101796945.geojson
+++ b/data/101/796/945/101796945.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Tvarditsa, Sliven Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6fec30eef5fbca5792fbfeb001ff25f",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101796945,
-    "wof:lastmodified":1566614106,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0422\u0432\u044a\u0440\u0434\u0438\u0446\u0430",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/796/953/101796953.geojson
+++ b/data/101/796/953/101796953.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":1321924
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2778651e663a3b80be8b8ed06de5eb47",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614090,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0417\u043b\u0430\u0442\u0438 \u0432\u043e\u0439\u0432\u043e\u0434\u0430",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/796/961/101796961.geojson
+++ b/data/101/796/961/101796961.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Kermen"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae8a45a57d99470f6ae435ed66f2dbab",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614100,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0435\u0440\u043c\u0435\u043d",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/796/963/101796963.geojson
+++ b/data/101/796/963/101796963.geojson
@@ -114,6 +114,9 @@
         "wd:id":"Q2610872"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c0dc8c96c54d923dd391351a048e974",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614092,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0420\u0443\u0435\u043d",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/965/101796965.geojson
+++ b/data/101/796/965/101796965.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Sungurlare"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a0ee6c2d020108a60c098fdd1df02a0",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614091,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0443\u043d\u0433\u0443\u0440\u043b\u0430\u0440\u0435",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/967/101796967.geojson
+++ b/data/101/796/967/101796967.geojson
@@ -188,6 +188,9 @@
         "wk:page":"Aytos"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1bf38fad00c0bb58ea50e5b734adf774",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614101,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0410\u0439\u0442\u043e\u0441",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/969/101796969.geojson
+++ b/data/101/796/969/101796969.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q2476853"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6a98f79bc32484d231704414eed4ccc",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614101,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0430\u0440\u043d\u043e\u0431\u0430\u0442",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/971/101796971.geojson
+++ b/data/101/796/971/101796971.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Kameno"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b1987fe52ed81276ba90fe09a3a795a",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614099,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041a\u0430\u043c\u0435\u043d\u043e",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/973/101796973.geojson
+++ b/data/101/796/973/101796973.geojson
@@ -195,6 +195,9 @@
         "wk:page":"Pomorie"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6cd3a48b26acabad994bb35bb9401857",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614106,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041f\u043e\u043c\u043e\u0440\u0438\u0435",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/977/101796977.geojson
+++ b/data/101/796/977/101796977.geojson
@@ -202,6 +202,9 @@
         "wk:page":"Sozopol"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d11566f1c711d02e8f7d97b5a9e076d",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614097,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u0421\u043e\u0437\u043e\u043f\u043e\u043b",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/979/101796979.geojson
+++ b/data/101/796/979/101796979.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Primorsko"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e5b349d215581258a590cbc7fd09a04",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614098,
+    "wof:lastmodified":1582345670,
     "wof:name":"\u041f\u0440\u0438\u043c\u043e\u0440\u0441\u043a\u043e",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/989/101796989.geojson
+++ b/data/101/796/989/101796989.geojson
@@ -138,6 +138,9 @@
         "qs_pg:id":907407
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12354b2eb50cdf3ea773612027f3d700",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614106,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0427\u0435\u0440\u043d\u043e\u043c\u043e\u0440\u0435\u0446",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/997/101796997.geojson
+++ b/data/101/796/997/101796997.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":1321904
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"33f1ee4a52435ed5a66ff2c8d2e585b6",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101796997,
-    "wof:lastmodified":1566614093,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0420\u043e\u0441\u0435\u043d",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/796/999/101796999.geojson
+++ b/data/101/796/999/101796999.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Letnitsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b894185e3346dfd6db6176f1dd03bef",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614093,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041b\u0435\u0442\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/001/101797001.geojson
+++ b/data/101/797/001/101797001.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Lukovit Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72b9812aa190176146dfe00516ebf1cc",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614017,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041b\u0443\u043a\u043e\u0432\u0438\u0442",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/003/101797003.geojson
+++ b/data/101/797/003/101797003.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Lovech"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da71b2251cfa768849cb8ad8c74c3fa1",
     "wof:hierarchy":[
         {
@@ -382,7 +385,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614029,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041b\u043e\u0432\u0435\u0447",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/005/101797005.geojson
+++ b/data/101/797/005/101797005.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Ugarchin"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee34a0a533bd136d288deb26279a0760",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614032,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0423\u0433\u044a\u0440\u0447\u0438\u043d",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/007/101797007.geojson
+++ b/data/101/797/007/101797007.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Teteven Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39cc933d02480fc342ab854bcda6c83b",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614013,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0422\u0435\u0442\u0435\u0432\u0435\u043d",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/009/101797009.geojson
+++ b/data/101/797/009/101797009.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Troyan Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb4945dee0aa64b787a0dbdd2837fad1",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614013,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0422\u0440\u043e\u044f\u043d",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/013/101797013.geojson
+++ b/data/101/797/013/101797013.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Apriltsi Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"580b3dade1d4e48d99e3f18fae82455c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614010,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0410\u043f\u0440\u0438\u043b\u0446\u0438",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/797/025/101797025.geojson
+++ b/data/101/797/025/101797025.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Mizia (town)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba6d521b5eeae18d71a1809bc72c3159",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614011,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u041c\u0438\u0437\u0438\u044f",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/027/101797027.geojson
+++ b/data/101/797/027/101797027.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Hayredin"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26d67361e2f6912eee32dc6eb3873b32",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101797027,
-    "wof:lastmodified":1566614027,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0425\u0430\u0439\u0440\u0435\u0434\u0438\u043d",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/031/101797031.geojson
+++ b/data/101/797/031/101797031.geojson
@@ -142,6 +142,9 @@
         "wd:id":"Q405228"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e30869f2eaa077d2218d44f7680c0d1a",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614014,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0411\u044f\u043b\u0430 \u0441\u043b\u0430\u0442\u0438\u043d\u0430",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/033/101797033.geojson
+++ b/data/101/797/033/101797033.geojson
@@ -111,6 +111,9 @@
         "wd:id":"Q2565618"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a77855fc0d956261e35b709030a84f5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614032,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0411\u043e\u0440\u043e\u0432\u0430\u043d",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/035/101797035.geojson
+++ b/data/101/797/035/101797035.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Krivodol, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c96d2f1df73deb580ea390f0cb12e12",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614030,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041a\u0440\u0438\u0432\u043e\u0434\u043e\u043b",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/037/101797037.geojson
+++ b/data/101/797/037/101797037.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Roman, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb87fe0a36be547d87284f7b63e1ad30",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614016,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0420\u043e\u043c\u0430\u043d",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/039/101797039.geojson
+++ b/data/101/797/039/101797039.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q406500"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a091259dd9d3783540bd3f4127396189",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614017,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041c\u0435\u0437\u0434\u0440\u0430",
     "wof:parent_id":85681817,
     "wof:placetype":"locality",

--- a/data/101/797/087/101797087.geojson
+++ b/data/101/797/087/101797087.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Brusartsi Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e427064a02705440162b69dbb2ea5a73",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614026,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0411\u0440\u0443\u0441\u0430\u0440\u0446\u0438",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/089/101797089.geojson
+++ b/data/101/797/089/101797089.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Medkovets Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6f52201293d4bb25bf42319e6730da50",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101797089,
-    "wof:lastmodified":1566614025,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041c\u0435\u0434\u043a\u043e\u0432\u0435\u0446",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/091/101797091.geojson
+++ b/data/101/797/091/101797091.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Boychinovtsi"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b198c238bce21184fc9941ed1177bdb5",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614012,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0411\u043e\u0439\u0447\u0438\u043d\u043e\u0432\u0446\u0438",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/093/101797093.geojson
+++ b/data/101/797/093/101797093.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Georgi Damyanovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b8cae9328a5c837ee5542a1e5fe235e9",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614033,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0413\u0435\u043e\u0440\u0433\u0438 \u0414\u0430\u043c\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/095/101797095.geojson
+++ b/data/101/797/095/101797095.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Chiprovtsi"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f941fa9219d56d35a559d5ae269f251f",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614030,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0427\u0438\u043f\u0440\u043e\u0432\u0446\u0438",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/097/101797097.geojson
+++ b/data/101/797/097/101797097.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Berkovitsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca93dcd1487befda54a86061085853ff",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614015,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0411\u0435\u0440\u043a\u043e\u0432\u0438\u0446\u0430",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/099/101797099.geojson
+++ b/data/101/797/099/101797099.geojson
@@ -171,6 +171,9 @@
         "wk:page":"Varshets"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"988dbb8643a3f8ae948339de60c1f066",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614014,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0412\u044a\u0440\u0448\u0435\u0446",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/797/141/101797141.geojson
+++ b/data/101/797/141/101797141.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Polski Trambesh"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d9274da69a776bd1dd16c7e6cd5f591",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614035,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041f\u043e\u043b\u0441\u043a\u0438 \u0422\u0440\u044a\u043c\u0431\u0435\u0448",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/143/101797143.geojson
+++ b/data/101/797/143/101797143.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Pavlikeni"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b804b09090f9a78be217937b2a6292e9",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614020,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041f\u0430\u0432\u043b\u0438\u043a\u0435\u043d\u0438",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/145/101797145.geojson
+++ b/data/101/797/145/101797145.geojson
@@ -132,6 +132,9 @@
         "wd:id":"Q405629"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abd7ccd6eadd48ff6e186c7dbe883908",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614018,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0421\u0442\u0440\u0430\u0436\u0438\u0446\u0430",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/147/101797147.geojson
+++ b/data/101/797/147/101797147.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Suhindol"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e76c3a848f841c6a778944ed9e1064b5",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614036,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0421\u0443\u0445\u0438\u043d\u0434\u043e\u043b",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/149/101797149.geojson
+++ b/data/101/797/149/101797149.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Zlataritsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5226ee842d15cfc198d6bfcb8128df9",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614037,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0417\u043b\u0430\u0442\u0430\u0440\u0438\u0446\u0430",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/151/101797151.geojson
+++ b/data/101/797/151/101797151.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Elena, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1b5d76a8f5cafc434b18ce72501264c",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614008,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0415\u043b\u0435\u043d\u0430",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/153/101797153.geojson
+++ b/data/101/797/153/101797153.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Debelets"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ae11666eb91f02bca5608ba0cd56c06",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101797153,
-    "wof:lastmodified":1566614022,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0414\u0435\u0431\u0435\u043b\u0435\u0446",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/163/101797163.geojson
+++ b/data/101/797/163/101797163.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":1085444
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f01b4eccf5f659b21d76628cf5ba4ddf",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614024,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041a\u0430\u0440\u0430\u0438\u0441\u0435\u043d",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/797/187/101797187.geojson
+++ b/data/101/797/187/101797187.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Knezha"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1794c66e59278ed70a88c4282ccdcdd",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":101797187,
-    "wof:lastmodified":1566614018,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041a\u043d\u0435\u0436\u0430",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/189/101797189.geojson
+++ b/data/101/797/189/101797189.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Dolna Mitropoliya"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88f70dc1f02b687e7340dbcdf0808018",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614019,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0414\u043e\u043b\u043d\u0430 \u041c\u0438\u0442\u0440\u043e\u043f\u043e\u043b\u0438\u044f",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/195/101797195.geojson
+++ b/data/101/797/195/101797195.geojson
@@ -150,6 +150,9 @@
         "wd:id":"Q405145"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"284e03a6389c9294dec1dd8c6743609c",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614006,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0414\u043e\u043b\u043d\u0438 \u0414\u044a\u0431\u043d\u0438\u043a",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/197/101797197.geojson
+++ b/data/101/797/197/101797197.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Pordim Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c338e59a4a49c886d6d43066bcc0eba1",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614024,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041f\u043e\u0440\u0434\u0438\u043c",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/199/101797199.geojson
+++ b/data/101/797/199/101797199.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Levski Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d115e6fecb0864a7cdf8d741e50b11a5",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614024,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041b\u0435\u0432\u0441\u043a\u0438",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/211/101797211.geojson
+++ b/data/101/797/211/101797211.geojson
@@ -110,6 +110,9 @@
         "qs_pg:id":1028729
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0e82baa86f3ebe3301adae07caab2a1",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101797211,
-    "wof:lastmodified":1566614009,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0414\u043e\u043b\u043d\u0438 \u041b\u0443\u043a\u043e\u0432\u0438\u0442",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/221/101797221.geojson
+++ b/data/101/797/221/101797221.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Slavyanovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eacc9116fb831512981d793c4e2027f7",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614010,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0421\u043b\u0430\u0432\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/247/101797247.geojson
+++ b/data/101/797/247/101797247.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Koynare"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9cbc359c3030b0ff535cb25bca88fd7",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614027,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041a\u043e\u0439\u043d\u0430\u0440\u0435",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/797/291/101797291.geojson
+++ b/data/101/797/291/101797291.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Popovo, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a37f4c82ebf67d9aca72657ca2fd6cb4",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614031,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041f\u043e\u043f\u043e\u0432\u043e",
     "wof:parent_id":85681839,
     "wof:placetype":"locality",

--- a/data/101/797/293/101797293.geojson
+++ b/data/101/797/293/101797293.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Targovishte"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48b0481c22aaea43011bb4d760b9a832",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614015,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0422\u044a\u0440\u0433\u043e\u0432\u0438\u0449\u0435",
     "wof:parent_id":85681839,
     "wof:placetype":"locality",

--- a/data/101/797/295/101797295.geojson
+++ b/data/101/797/295/101797295.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Antonovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10eefe601efa236a64c89d60890f9777",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614013,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0410\u043d\u0442\u043e\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681839,
     "wof:placetype":"locality",

--- a/data/101/797/297/101797297.geojson
+++ b/data/101/797/297/101797297.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Omurtag Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b077259ba20ad36f6dca4d0e8d9d60ce",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614033,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041e\u043c\u0443\u0440\u0442\u0430\u0433",
     "wof:parent_id":85681839,
     "wof:placetype":"locality",

--- a/data/101/797/313/101797313.geojson
+++ b/data/101/797/313/101797313.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Dunavtsi"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56a8bfe4b64792c021063a3075e9bcf7",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614021,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0414\u0443\u043d\u0430\u0432\u0446\u0438",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/315/101797315.geojson
+++ b/data/101/797/315/101797315.geojson
@@ -126,6 +126,9 @@
         "wd:id":"Q405591"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9c4663c7b5be0241fe33b6a0c49099f",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614019,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0413\u0440\u0430\u043c\u0430\u0434\u0430",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/319/101797319.geojson
+++ b/data/101/797/319/101797319.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Makresh Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b46e1f838e7b66a7bbe990415e50807",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614036,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041c\u0430\u043a\u0440\u0435\u0448",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/321/101797321.geojson
+++ b/data/101/797/321/101797321.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Dimovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"559e2ee6a87d34d9d00ee0107fecc703",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614036,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0414\u0438\u043c\u043e\u0432\u043e",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/323/101797323.geojson
+++ b/data/101/797/323/101797323.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Belogradchik Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc2fbc6385363c027487471c6bbb7b87",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614019,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0411\u0435\u043b\u043e\u0433\u0440\u0430\u0434\u0447\u0438\u043a",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/325/101797325.geojson
+++ b/data/101/797/325/101797325.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q2715178"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7b01255ebafa86b87624bcced11e178",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614021,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0420\u0443\u0436\u0438\u043d\u0446\u0438",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/327/101797327.geojson
+++ b/data/101/797/327/101797327.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Chuprene Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"95a79ab524ec7c5b1f8870cde445779a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614034,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0427\u0443\u043f\u0440\u0435\u043d\u0435",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/329/101797329.geojson
+++ b/data/101/797/329/101797329.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q2079200"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04db6bf9a782b5411c32375b9f9678da",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614034,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0410\u0440\u0447\u0430\u0440",
     "wof:parent_id":85681841,
     "wof:placetype":"locality",

--- a/data/101/797/351/101797351.geojson
+++ b/data/101/797/351/101797351.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q405573"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1766909a46e7c7a4bb292839a2183734",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614023,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0414\u044a\u043b\u0433\u043e\u043f\u043e\u043b",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/797/355/101797355.geojson
+++ b/data/101/797/355/101797355.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Dolni Chiflik Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b471d0a35a33bc31885edaf23476ec4",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614007,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0414\u043e\u043b\u043d\u0438 \u0447\u0438\u0444\u043b\u0438\u043a",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/797/357/101797357.geojson
+++ b/data/101/797/357/101797357.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Byala, Varna Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25b19a80b1e32a22fc79d34413918731",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614022,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0411\u044f\u043b\u0430",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/797/363/101797363.geojson
+++ b/data/101/797/363/101797363.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Kaspichan Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74fa65f651e8ba5856dd6c0e9e502025",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101797363,
-    "wof:lastmodified":1566614008,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u041a\u0430\u0441\u043f\u0438\u0447\u0430\u043d",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/383/101797383.geojson
+++ b/data/101/797/383/101797383.geojson
@@ -113,6 +113,9 @@
         "qs_pg:id":1272925
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbdfe6d26c29e93c19a60b92bd7bd843",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614018,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u041f\u0435\u0442 \u043c\u043e\u0433\u0438\u043b\u0438",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/399/101797399.geojson
+++ b/data/101/797/399/101797399.geojson
@@ -185,6 +185,9 @@
         "wd:id":"Q318889"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72a3e5feebeeb8dd60a75cfc5c84d462",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":101797399,
-    "wof:lastmodified":1566614007,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u041f\u043b\u0438\u0441\u043a\u0430",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/405/101797405.geojson
+++ b/data/101/797/405/101797405.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Madara (village)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc6934fb882f28c38beca3616d1fd50a",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614030,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041c\u0430\u0434\u0430\u0440\u0430",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/409/101797409.geojson
+++ b/data/101/797/409/101797409.geojson
@@ -205,6 +205,9 @@
         "wk:page":"Veliki Preslav"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eeffcd1f14767257dc004cf004fc4262",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614014,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u0438 \u041f\u0440\u0435\u0441\u043b\u0430\u0432",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/411/101797411.geojson
+++ b/data/101/797/411/101797411.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Smyadovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf1e91e31d1d0e73538dbc42bc93ec5a",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614027,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0421\u043c\u044f\u0434\u043e\u0432\u043e",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/413/101797413.geojson
+++ b/data/101/797/413/101797413.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Varbitsa (town)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3218c9ba1f394e4abde404c4cf269314",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614010,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0412\u044a\u0440\u0431\u0438\u0446\u0430",
     "wof:parent_id":85681853,
     "wof:placetype":"locality",

--- a/data/101/797/449/101797449.geojson
+++ b/data/101/797/449/101797449.geojson
@@ -110,6 +110,9 @@
         "qs_pg:id":477894
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"357f22c44324ecb24dd63b106f2514f1",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614009,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0415\u0437\u0435\u0440\u0447\u0435",
     "wof:parent_id":85681857,
     "wof:placetype":"locality",

--- a/data/101/797/467/101797467.geojson
+++ b/data/101/797/467/101797467.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":235314
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0cbd0e289a9dfa8080cf7fa6df58f35e",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614029,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041d\u0438\u043a\u043e\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/797/475/101797475.geojson
+++ b/data/101/797/475/101797475.geojson
@@ -102,6 +102,9 @@
         "wd:id":"Q2652929"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b370b8d601e4c56c71a0ddaabc5a6e5",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614027,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0411\u0430\u0441\u0430\u0440\u0431\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/797/489/101797489.geojson
+++ b/data/101/797/489/101797489.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q2654860"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96369704631271b4a9dbee69e1364ddc",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614029,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0429\u0440\u044a\u043a\u043b\u0435\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/797/493/101797493.geojson
+++ b/data/101/797/493/101797493.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Senovo, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2941e589ae58b83d1e0f78568a4bdff",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614029,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0421\u0435\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681861,
     "wof:placetype":"locality",

--- a/data/101/797/523/101797523.geojson
+++ b/data/101/797/523/101797523.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q2653330"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9fdcffde75ecf58c1b5aa028af15ff3",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614036,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0411\u044a\u043b\u0433\u0430\u0440\u0435\u0432\u043e",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/797/525/101797525.geojson
+++ b/data/101/797/525/101797525.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Obrochishte"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9c3a029c39bb73f8fd1526bd8d81a81",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614035,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041e\u0431\u0440\u043e\u0447\u0438\u0449\u0435",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/101/797/979/101797979.geojson
+++ b/data/101/797/979/101797979.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q7837964"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f19ea43d92f3ab7771396bebdcf2aa18",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614018,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0422\u0440\u0435\u043a\u043b\u044f\u043d\u043e",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/797/981/101797981.geojson
+++ b/data/101/797/981/101797981.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Bobov Dol"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c047b91bd31e88e63dee1c04e8c94cf7",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614037,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0411\u043e\u0431\u043e\u0432 \u0434\u043e\u043b",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/797/985/101797985.geojson
+++ b/data/101/797/985/101797985.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Sapareva Banya"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04e5e24ccc3ab7c8ed94ee39cc53ed63",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614020,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0421\u0430\u043f\u0430\u0440\u0435\u0432\u0430 \u0431\u0430\u043d\u044f",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/797/989/101797989.geojson
+++ b/data/101/797/989/101797989.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Topolovgrad"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8c6e04cd888ad4c40f2b61ef4d67f957",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614035,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0422\u043e\u043f\u043e\u043b\u043e\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/797/991/101797991.geojson
+++ b/data/101/797/991/101797991.geojson
@@ -241,6 +241,9 @@
         "wk:page":"Dimitrovgrad, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6e8898a10be44a14b2d357296e317c9",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614006,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0414\u0438\u043c\u0438\u0442\u0440\u043e\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/797/993/101797993.geojson
+++ b/data/101/797/993/101797993.geojson
@@ -139,6 +139,9 @@
         "wd:id":"Q5474197"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"503497844f5f4a1f2a841c010fb32fee",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614023,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0421\u0438\u043c\u0435\u043e\u043d\u043e\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/797/995/101797995.geojson
+++ b/data/101/797/995/101797995.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Harmanli"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30e065fe14243d5dd282ea222a4a2ff5",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614022,
+    "wof:lastmodified":1582345664,
     "wof:name":"\u0425\u0430\u0440\u043c\u0430\u043d\u043b\u0438",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/797/997/101797997.geojson
+++ b/data/101/797/997/101797997.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q405507"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d727814a62517be0a1915f064b85f3f",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614007,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u0421\u0442\u0440\u0435\u043b\u0447\u0430",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/797/999/101797999.geojson
+++ b/data/101/797/999/101797999.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Panagyurishte Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f125116158db43a735a1d5532a5c8bf2",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614008,
+    "wof:lastmodified":1582345663,
     "wof:name":"\u041f\u0430\u043d\u0430\u0433\u044e\u0440\u0438\u0449\u0435",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/798/003/101798003.geojson
+++ b/data/101/798/003/101798003.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Lesichovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4ee9eb6afefa47552be491238f3a0b8",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614083,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041b\u0435\u0441\u0438\u0447\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/798/005/101798005.geojson
+++ b/data/101/798/005/101798005.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Septemvri"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"78b85e0a993df540ec974ca55aa23391",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614085,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0435\u043f\u0442\u0435\u043c\u0432\u0440\u0438",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/798/021/101798021.geojson
+++ b/data/101/798/021/101798021.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Tran, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ef085d59e94b758468f1af2afc52461",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614083,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0422\u0440\u044a\u043d",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/798/023/101798023.geojson
+++ b/data/101/798/023/101798023.geojson
@@ -143,6 +143,9 @@
         "wd:id":"Q390361"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"357e2291c8c5a1b8695fc6a0d1794933",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614063,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0411\u0440\u0435\u0437\u043d\u0438\u043a",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/798/025/101798025.geojson
+++ b/data/101/798/025/101798025.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Kovachevtsi, Pernik Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81fa18cdd25a6f9b529a0bbd12d46a6a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101798025,
-    "wof:lastmodified":1566614065,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u043e\u0432\u0430\u0447\u0435\u0432\u0446\u0438",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/798/027/101798027.geojson
+++ b/data/101/798/027/101798027.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Radomir (town)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9dec55c70f307d9fe24c9db2bff55ba0",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614080,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0420\u0430\u0434\u043e\u043c\u0438\u0440",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/798/029/101798029.geojson
+++ b/data/101/798/029/101798029.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Zemen"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"735bfe492176787b5c3e93d7071b6d1e",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614080,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0417\u0435\u043c\u0435\u043d",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/798/057/101798057.geojson
+++ b/data/101/798/057/101798057.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Buhovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e52ec53f8408a2be544927904804fd70",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":101798057,
-    "wof:lastmodified":1566614084,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u0443\u0445\u043e\u0432\u043e",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/798/061/101798061.geojson
+++ b/data/101/798/061/101798061.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Bankya"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"51a7513e7ab04e1dc697bca1b8a56b1e",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101798061,
-    "wof:lastmodified":1566614084,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u0430\u043d\u043a\u044f",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/798/071/101798071.geojson
+++ b/data/101/798/071/101798071.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Hisarya, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14d218c1191a429817f7f9c1924a4464",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614066,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0425\u0438\u0441\u0430\u0440\u044f",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/075/101798075.geojson
+++ b/data/101/798/075/101798075.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kaloyanovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f621486feb2c515b9b163ba43097476",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614081,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u0430\u043b\u043e\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/077/101798077.geojson
+++ b/data/101/798/077/101798077.geojson
@@ -142,6 +142,9 @@
         "wd:id":"Q405203"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"982cbafd9994acca3b49035463408949",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614064,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0411\u0440\u0435\u0437\u043e\u0432\u043e",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/079/101798079.geojson
+++ b/data/101/798/079/101798079.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Rakovski (town)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11470573f2cc68f28dd4638cd2e32be6",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614064,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0420\u0430\u043a\u043e\u0432\u0441\u043a\u0438",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/083/101798083.geojson
+++ b/data/101/798/083/101798083.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Sadovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93573a0b69cb5cd71c4e583b57afef9a",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614065,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0421\u0430\u0434\u043e\u0432\u043e",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/121/101798121.geojson
+++ b/data/101/798/121/101798121.geojson
@@ -134,6 +134,9 @@
         "qs_pg:id":261759
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39a9a755c0e45d0cd9a4cb76cbea7b37",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614074,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u043b\u0438\u0441\u0443\u0440\u0430",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/798/137/101798137.geojson
+++ b/data/101/798/137/101798137.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Maglizh"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"707f2946c3d50c7fa87431fe64635a79",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614078,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041c\u044a\u0433\u043b\u0438\u0436",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/139/101798139.geojson
+++ b/data/101/798/139/101798139.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Pavel Banya"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ca6dbdae116078fb99bc07dcc120d6c",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614077,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041f\u0430\u0432\u0435\u043b \u0431\u0430\u043d\u044f",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/141/101798141.geojson
+++ b/data/101/798/141/101798141.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q899684"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1e812f2a66cbda12e86152140fc2ecb",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614088,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u0440\u0430\u0442\u044f \u0414\u0430\u0441\u043a\u0430\u043b\u043e\u0432\u0438",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/143/101798143.geojson
+++ b/data/101/798/143/101798143.geojson
@@ -132,6 +132,9 @@
         "wd:id":"Q407383"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54424ed625444d2c27fb8815efb86bec",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614073,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0420\u0430\u0434\u043d\u0435\u0432\u043e",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/147/101798147.geojson
+++ b/data/101/798/147/101798147.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Opan"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6bbbf259b4a087617e4f4556e1c091c3",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614089,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u041e\u043f\u0430\u043d",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/149/101798149.geojson
+++ b/data/101/798/149/101798149.geojson
@@ -155,6 +155,9 @@
         "wd:id":"Q407340"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"014f7204c3f880210398605e39df401a",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614089,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0427\u0438\u0440\u043f\u0430\u043d",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/151/101798151.geojson
+++ b/data/101/798/151/101798151.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Galabovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7687239b9885f4e5abca5dbf293efd2",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614063,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0413\u044a\u043b\u044a\u0431\u043e\u0432\u043e",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/183/101798183.geojson
+++ b/data/101/798/183/101798183.geojson
@@ -282,6 +282,9 @@
         "wd:id":"Q170415"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"addbdfce3486ea3efcb71ffdcacbd840",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614087,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u043e\u0433\u043e\u043c\u0438\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681783,
     "wof:placetype":"locality",

--- a/data/101/798/191/101798191.geojson
+++ b/data/101/798/191/101798191.geojson
@@ -174,6 +174,9 @@
         "qs_pg:id":1081554
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5dd0a96920cc6b8948399a3069c07a33",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614076,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041d\u043e\u0432\u0430\u0447\u0435\u043d\u0435",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/201/101798201.geojson
+++ b/data/101/798/201/101798201.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Dragoman, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfd099c5ac7b38a2cb095525ddadc88c",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614084,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0414\u0440\u0430\u0433\u043e\u043c\u0430\u043d",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/203/101798203.geojson
+++ b/data/101/798/203/101798203.geojson
@@ -282,6 +282,9 @@
         "wd:id":"Q3135749"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81624f12520a65efb30fb1f1fba2e0ad",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614069,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0421\u043b\u0438\u0432\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/205/101798205.geojson
+++ b/data/101/798/205/101798205.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Etropole"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"debff314e618b32af4028b7e9cb9eda4",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614071,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0415\u0442\u0440\u043e\u043f\u043e\u043b\u0435",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/207/101798207.geojson
+++ b/data/101/798/207/101798207.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q671522"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7edc664b0f7add39ba4e6f216b704f6",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614083,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u043e\u0441\u0442\u0438\u043d\u0431\u0440\u043e\u0434",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/209/101798209.geojson
+++ b/data/101/798/209/101798209.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Mirkovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6cff91104d3c9087d784a760fd26c7c2",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614083,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041c\u0438\u0440\u043a\u043e\u0432\u043e",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/211/101798211.geojson
+++ b/data/101/798/211/101798211.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q2994088"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"292040606a965993501d43b850e2d0f3",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614063,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0413\u043e\u0440\u043d\u0430 \u041c\u0430\u043b\u0438\u043d\u0430",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/213/101798213.geojson
+++ b/data/101/798/213/101798213.geojson
@@ -142,6 +142,9 @@
         "wd:id":"Q406042"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eca6cc90ba0d123a3f5277d172d97c01",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614082,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0415\u043b\u0438\u043d \u041f\u0435\u043b\u0438\u043d",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/215/101798215.geojson
+++ b/data/101/798/215/101798215.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Ihtiman"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"420a3b795478c64069af3573b11d5d1d",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614079,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0418\u0445\u0442\u0438\u043c\u0430\u043d",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/219/101798219.geojson
+++ b/data/101/798/219/101798219.geojson
@@ -179,6 +179,9 @@
         "wd:id":"Q388070"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"017aafaccf60df2fe49868b2f05f6d91",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614065,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0421\u0430\u043c\u043e\u043a\u043e\u0432",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/221/101798221.geojson
+++ b/data/101/798/221/101798221.geojson
@@ -143,6 +143,9 @@
         "wd:id":"Q405248"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7bbb4c604786654a65396a8f4dd622fa",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614065,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0414\u043e\u043b\u043d\u0430 \u0411\u0430\u043d\u044f",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/223/101798223.geojson
+++ b/data/101/798/223/101798223.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Anton, Sofia Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5f7a40bde5d0bd55f6e25c7a1611d1c",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614080,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0410\u043d\u0442\u043e\u043d",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/227/101798227.geojson
+++ b/data/101/798/227/101798227.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2301724"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7ed8fcdc006d470eaf3eaadf34fb231",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614063,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0427\u0430\u0432\u0434\u0430\u0440",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/229/101798229.geojson
+++ b/data/101/798/229/101798229.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Koprivshtitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4cfbcbd804285bd7e62c49c2dc22ac86",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614063,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041a\u043e\u043f\u0440\u0438\u0432\u0449\u0438\u0446\u0430",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/231/101798231.geojson
+++ b/data/101/798/231/101798231.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Bozhurishte"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc7f57de21370758ddbe45bad6bf0dcf",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614083,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0411\u043e\u0436\u0443\u0440\u0438\u0449\u0435",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/233/101798233.geojson
+++ b/data/101/798/233/101798233.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":907458
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a33bee0a1335cb1d0ae5047e543af696",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101798233,
-    "wof:lastmodified":1566614072,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u043e\u0441\u0442\u0435\u043d\u0435\u0446",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/798/255/101798255.geojson
+++ b/data/101/798/255/101798255.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Elhovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3203e925c3fde236f67624379201f78",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614086,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0415\u043b\u0445\u043e\u0432\u043e",
     "wof:parent_id":85681793,
     "wof:placetype":"locality",

--- a/data/101/798/257/101798257.geojson
+++ b/data/101/798/257/101798257.geojson
@@ -151,6 +151,9 @@
         "wd:id":"Q406618"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"357c37965956fc8379fe93d9a5746433",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614067,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0411\u043e\u043b\u044f\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681793,
     "wof:placetype":"locality",

--- a/data/101/798/301/101798301.geojson
+++ b/data/101/798/301/101798301.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Nova Zagora"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3707444d62719d807b020e4152f5673a",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614062,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041d\u043e\u0432\u0430 \u0417\u0430\u0433\u043e\u0440\u0430",
     "wof:parent_id":85681799,
     "wof:placetype":"locality",

--- a/data/101/798/313/101798313.geojson
+++ b/data/101/798/313/101798313.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Obzor"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aecb5c866622a841be1515b5a976c070",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101798313,
-    "wof:lastmodified":1566614074,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041e\u0431\u0437\u043e\u0440",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/798/347/101798347.geojson
+++ b/data/101/798/347/101798347.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Sveti Vlas"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67227ae5652fef85694abbf9c8e7d831",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101798347,
-    "wof:lastmodified":1566614074,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0421\u0432\u0435\u0442\u0438 \u0412\u043b\u0430\u0441",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/798/365/101798365.geojson
+++ b/data/101/798/365/101798365.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q1500384"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4ddb0f4d41dc1ad853c62dfdbed1277",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614060,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0421\u0440\u0435\u0434\u0435\u0446",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/798/367/101798367.geojson
+++ b/data/101/798/367/101798367.geojson
@@ -133,6 +133,9 @@
         "wd:id":"Q2721122"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64314ec5e1003c83d23def9a920da8d5",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614077,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u0426\u0430\u0440\u0435\u0432\u043e",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/798/373/101798373.geojson
+++ b/data/101/798/373/101798373.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1084877
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dcbaec6f788d61c60d18640cdf578da7",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614088,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438 \u0438\u0437\u0432\u043e\u0440",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/798/383/101798383.geojson
+++ b/data/101/798/383/101798383.geojson
@@ -108,6 +108,9 @@
         "wd:id":"Q2598850"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"917f3a1988f66749eed127d0c0882e82",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614072,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041e\u0440\u0435\u0448\u0430\u043a",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/798/391/101798391.geojson
+++ b/data/101/798/391/101798391.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Byala Cherkva"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c45e89cab6e9996a64343966b96d6ab6",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614060,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0411\u044f\u043b\u0430 \u0447\u0435\u0440\u043a\u0432\u0430",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/798/409/101798409.geojson
+++ b/data/101/798/409/101798409.geojson
@@ -104,6 +104,9 @@
         "wd:id":"Q406624"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"119e243ceec1af62b56d167cb76b2ea3",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101798409,
-    "wof:lastmodified":1566614070,
+    "wof:lastmodified":1582345668,
     "wof:name":"\u041a\u0438\u043b\u0438\u0444\u0430\u0440\u0435\u0432\u043e",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/798/457/101798457.geojson
+++ b/data/101/798/457/101798457.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":1349322
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a9efc0819e1d16d7dccefcdfa356f67",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614084,
+    "wof:lastmodified":1582345669,
     "wof:name":"\u0421\u0442\u0430\u0440\u043e \u041e\u0440\u044f\u0445\u043e\u0432\u043e",
     "wof:parent_id":85681847,
     "wof:placetype":"locality",

--- a/data/101/799/101/101799101.geojson
+++ b/data/101/799/101/101799101.geojson
@@ -180,6 +180,9 @@
         "wk:page":"Karlovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"773f43965487df09679679e944ea664c",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614052,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0430\u0440\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/103/101799103.geojson
+++ b/data/101/799/103/101799103.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Devin, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b370e339f462b84c125fc154fd1096a8",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101799103,
-    "wof:lastmodified":1566614038,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0414\u0435\u0432\u0438\u043d",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/105/101799105.geojson
+++ b/data/101/799/105/101799105.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Chepelare"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12951baae8dac043a7464c307bc5084d",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614040,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0427\u0435\u043f\u0435\u043b\u0430\u0440\u0435",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/109/101799109.geojson
+++ b/data/101/799/109/101799109.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Dospat"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54d8bc583c795beb8c590e47b5b6720e",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614051,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0414\u043e\u0441\u043f\u0430\u0442",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/111/101799111.geojson
+++ b/data/101/799/111/101799111.geojson
@@ -269,6 +269,9 @@
         "wk:page":"Smolyan"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9079e5c7c9b5704341bcc1ffee296a25",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614048,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u043c\u043e\u043b\u044f\u043d",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/115/101799115.geojson
+++ b/data/101/799/115/101799115.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Nedelino"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c877dd65ae43e0f07b16e06f7455c89",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614056,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041d\u0435\u0434\u0435\u043b\u0438\u043d\u043e",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/119/101799119.geojson
+++ b/data/101/799/119/101799119.geojson
@@ -152,6 +152,9 @@
         "wd:id":"Q1790862"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ae19178763308adc35eb00548bf2397",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614049,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0417\u043b\u0430\u0442\u043e\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/799/123/101799123.geojson
+++ b/data/101/799/123/101799123.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Chernoochene"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a705118744b154fa9bdb919cc5916a8",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614057,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0427\u0435\u0440\u043d\u043e\u043e\u0447\u0435\u043d\u0435",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/799/125/101799125.geojson
+++ b/data/101/799/125/101799125.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q407347"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50f38691ff2243260d8dfed0ebc5718f",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614058,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0410\u0440\u0434\u0438\u043d\u043e",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/799/129/101799129.geojson
+++ b/data/101/799/129/101799129.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Dzhebel"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cfe775a551b99a6b1bc038168b1ce69f",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614047,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0414\u0436\u0435\u0431\u0435\u043b",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/799/131/101799131.geojson
+++ b/data/101/799/131/101799131.geojson
@@ -150,6 +150,9 @@
         "wd:id":"Q406057"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"409a0d9f83676c16aee8522e4c1e48c6",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614050,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0440\u0443\u043c\u043e\u0432\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/799/133/101799133.geojson
+++ b/data/101/799/133/101799133.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Kirkovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ae967421179124e81c3d2c2009c30b2",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614040,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0438\u0440\u043a\u043e\u0432\u043e",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/799/139/101799139.geojson
+++ b/data/101/799/139/101799139.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Yakoruda"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0185420d207065b1896f11f256f50d1",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614052,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u042f\u043a\u043e\u0440\u0443\u0434\u0430",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/141/101799141.geojson
+++ b/data/101/799/141/101799141.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Belitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"535632de7e0dcd6865cc86ee05a160a0",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614058,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0411\u0435\u043b\u0438\u0446\u0430",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/143/101799143.geojson
+++ b/data/101/799/143/101799143.geojson
@@ -151,6 +151,9 @@
         "wd:id":"Q1897942"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb1bebd0f54ee1c08df37844bf195e48",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614048,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u0438\u043c\u0438\u0442\u043b\u0438",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/145/101799145.geojson
+++ b/data/101/799/145/101799145.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Razlog"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d91231d673c71a06e1c191ed9d814be",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614047,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0420\u0430\u0437\u043b\u043e\u0433",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/147/101799147.geojson
+++ b/data/101/799/147/101799147.geojson
@@ -189,6 +189,9 @@
         "wk:page":"Bansko"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e95ebfba5c11cfdece8762a5fe02c5e",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614059,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0411\u0430\u043d\u0441\u043a\u043e",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/149/101799149.geojson
+++ b/data/101/799/149/101799149.geojson
@@ -151,6 +151,9 @@
         "qs_pg:id":128930
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1a389cc2e0804ef5643cd23b6a30a68",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101799149,
-    "wof:lastmodified":1566614059,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041a\u0440\u0435\u0441\u043d\u0430",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/151/101799151.geojson
+++ b/data/101/799/151/101799151.geojson
@@ -124,6 +124,9 @@
         "wk:page":"Satovcha"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd8c5e7525a20833eb22025cc5a7aac9",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614041,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u0430\u0442\u043e\u0432\u0447\u0430",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/155/101799155.geojson
+++ b/data/101/799/155/101799155.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Garmen"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3afb35d7d65556fd66f0488049306f52",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614051,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0413\u044a\u0440\u043c\u0435\u043d",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/157/101799157.geojson
+++ b/data/101/799/157/101799157.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Gotse Delchev, Blagoevgrad Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ac4a504971b3a3b5ce5e05793156074",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614039,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0413\u043e\u0446\u0435 \u0414\u0435\u043b\u0447\u0435\u0432",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/159/101799159.geojson
+++ b/data/101/799/159/101799159.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Sandanski"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef3d2dc6843f26e939ba3ae4907af906",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614039,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u0430\u043d\u0434\u0430\u043d\u0441\u043a\u0438",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/161/101799161.geojson
+++ b/data/101/799/161/101799161.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Hadzhidimovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90a08dfe18d13d0f13786fd85b41a1ae",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101799161,
-    "wof:lastmodified":1566614039,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0425\u0430\u0434\u0436\u0438\u0434\u0438\u043c\u043e\u0432\u043e",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/163/101799163.geojson
+++ b/data/101/799/163/101799163.geojson
@@ -190,6 +190,9 @@
         "qs_pg:id":1095915
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"94828aeb614833ff5ea6c97ab65e35ec",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":101799163,
-    "wof:lastmodified":1566614051,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041f\u0435\u0442\u0440\u0438\u0447",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/165/101799165.geojson
+++ b/data/101/799/165/101799165.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Strumyani"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb2f47c34a840a8f8cc68ff3d6119487",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614050,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u0442\u0440\u0443\u043c\u044f\u043d\u0438",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/169/101799169.geojson
+++ b/data/101/799/169/101799169.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Dobrinishte"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88b4729c0182d9e9802177d9c2279d80",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101799169,
-    "wof:lastmodified":1566614042,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0414\u043e\u0431\u0440\u0438\u043d\u0438\u0449\u0435",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/799/177/101799177.geojson
+++ b/data/101/799/177/101799177.geojson
@@ -98,6 +98,9 @@
         "woe:id":839396
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7303906a3d8cd723872386daf562da40",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614057,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0421\u0430\u043f\u0430\u0440\u0435\u0432\u043e",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/799/179/101799179.geojson
+++ b/data/101/799/179/101799179.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Nevestino, Kyustendil Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2bf7a6bb6926b581a6a6305e0ec4c3c1",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614058,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041d\u0435\u0432\u0435\u0441\u0442\u0438\u043d\u043e",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/799/181/101799181.geojson
+++ b/data/101/799/181/101799181.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Boboshevo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92101656b48c97372bb0f6f462b33ceb",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614049,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0411\u043e\u0431\u043e\u0448\u0435\u0432\u043e",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/799/183/101799183.geojson
+++ b/data/101/799/183/101799183.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Rila, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a080cfaf0e3ecd86cb2b2f94c42bdc91",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614057,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0420\u0438\u043b\u0430",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/799/185/101799185.geojson
+++ b/data/101/799/185/101799185.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Kocherinovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d615ca4292b63d7a2cff2cc2e935e2c4",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614059,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041a\u043e\u0447\u0435\u0440\u0438\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/799/209/101799209.geojson
+++ b/data/101/799/209/101799209.geojson
@@ -154,6 +154,9 @@
         "wd:id":"Q405367"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf89f67aeabd8f3a6510f4d7afff63ec",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614055,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041b\u044e\u0431\u0438\u043c\u0435\u0446",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/799/211/101799211.geojson
+++ b/data/101/799/211/101799211.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Stambolovo, Haskovo Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"788bbd1cf2b8bfc0df7c50636db5d742",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614042,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0421\u0442\u0430\u043c\u0431\u043e\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/799/213/101799213.geojson
+++ b/data/101/799/213/101799213.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Svilengrad"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f08e520109ffe07dc052b53d538aa70",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614054,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0421\u0432\u0438\u043b\u0435\u043d\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/799/215/101799215.geojson
+++ b/data/101/799/215/101799215.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Madzharovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc2240ae4dd3cad7eaf1272bc702a21e",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614053,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041c\u0430\u0434\u0436\u0430\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/799/217/101799217.geojson
+++ b/data/101/799/217/101799217.geojson
@@ -171,6 +171,9 @@
         "wk:page":"Ivaylovgrad"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4dfeba94ce1216a82a9623a7f3c1291c",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614043,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0418\u0432\u0430\u0439\u043b\u043e\u0432\u0440\u0430\u0434",
     "wof:parent_id":85681759,
     "wof:placetype":"locality",

--- a/data/101/799/237/101799237.geojson
+++ b/data/101/799/237/101799237.geojson
@@ -89,6 +89,9 @@
         "qs_pg:id":1167305
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"599ac69061a95635deb42fdc9727bf72",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614055,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041e\u0433\u043d\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/257/101799257.geojson
+++ b/data/101/799/257/101799257.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q407705"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"299bae55bfa8d1ca8b619f17f938383c",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534985847,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0411\u0435\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/283/101799283.geojson
+++ b/data/101/799/283/101799283.geojson
@@ -186,6 +186,9 @@
         "wd:id":"Q405114"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63f6118cc9ca5b0c9d5110ebcabb53ae",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614052,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0412\u0435\u043b\u0438\u043d\u0433\u0440\u0430\u0434",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/285/101799285.geojson
+++ b/data/101/799/285/101799285.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Peshtera"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e63790861d5cb7f52a6062f22497e65",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614054,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041f\u0435\u0449\u0435\u0440\u0430",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/287/101799287.geojson
+++ b/data/101/799/287/101799287.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q405842"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"391418c69cd4333b044d3d36ebda0d47",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614043,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0411\u0440\u0430\u0446\u0438\u0433\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/289/101799289.geojson
+++ b/data/101/799/289/101799289.geojson
@@ -123,6 +123,9 @@
         "wd:id":"Q405554"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c60c3ab981393e166c1b3304acdf86f",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614043,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0420\u0430\u043a\u0438\u0442\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/291/101799291.geojson
+++ b/data/101/799/291/101799291.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Batak, Bulgaria"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6fffda0cd709601d499eef726b78c281",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614055,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0411\u0430\u0442\u0430\u043a",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/799/305/101799305.geojson
+++ b/data/101/799/305/101799305.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q1075378"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0188babfa46d55d211ce9287c11324c6",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614052,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u0420\u0443\u0434\u0430\u0440\u0446\u0438",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/799/307/101799307.geojson
+++ b/data/101/799/307/101799307.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q4222860"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19c26744567a4dbee784d00feff47e8b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614037,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041a\u043b\u0430\u0434\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681767,
     "wof:placetype":"locality",

--- a/data/101/799/309/101799309.geojson
+++ b/data/101/799/309/101799309.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q2653459"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f6b74054f16c172c95120de817af8a6",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101799309,
-    "wof:lastmodified":1566614038,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u0412\u043b\u0430\u0434\u0430\u044f",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/799/313/101799313.geojson
+++ b/data/101/799/313/101799313.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Kokalyane"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25728fa253c4fcb5b25fb737198897b1",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101799313,
-    "wof:lastmodified":1566614049,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u043e\u043a\u0430\u043b\u044f\u043d\u0435",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/799/329/101799329.geojson
+++ b/data/101/799/329/101799329.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Kalofer"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4cc0f8173f405c54cfae5e07e5e905d4",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614057,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041a\u0430\u043b\u043e\u0444\u0435\u0440",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/379/101799379.geojson
+++ b/data/101/799/379/101799379.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q2654185"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81a16691121108467ee173a1cdd935f9",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614046,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0440\u0443\u043c\u043e\u0432\u043e",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/391/101799391.geojson
+++ b/data/101/799/391/101799391.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Perushtitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3da38ad67ccf918cf276d683d98ed40a",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614038,
+    "wof:lastmodified":1582345665,
     "wof:name":"\u041f\u0435\u0440\u0443\u0449\u0438\u0446\u0430",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/393/101799393.geojson
+++ b/data/101/799/393/101799393.geojson
@@ -133,6 +133,9 @@
         "wd:id":"Q406822"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80e4a7387a93a8484f4ce26f7213818a",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":101799393,
-    "wof:lastmodified":1566614052,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0440\u0438\u0447\u0438\u043c",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/395/101799395.geojson
+++ b/data/101/799/395/101799395.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Kuklen"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d37d9f296d4d53c2d5a8b78e52e199a",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614050,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041a\u0443\u043a\u043b\u0435\u043d",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/397/101799397.geojson
+++ b/data/101/799/397/101799397.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Laki, Plovdiv Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ab178cfe3359b9d5189738b6fbb9e4f",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614041,
+    "wof:lastmodified":1582345666,
     "wof:name":"\u041b\u044a\u043a\u0438",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/799/443/101799443.geojson
+++ b/data/101/799/443/101799443.geojson
@@ -143,6 +143,9 @@
         "wd:id":"Q1993655"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f224e5c57f5c7de7d2a883dd0bd965d",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614053,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u041a\u0438\u0442\u0435\u043d",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/799/445/101799445.geojson
+++ b/data/101/799/445/101799445.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Ahtopol"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b0f95b997da262db84ab267e70b8975",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614054,
+    "wof:lastmodified":1582345667,
     "wof:name":"\u0410\u0445\u0442\u043e\u043f\u043e\u043b",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/800/223/101800223.geojson
+++ b/data/101/800/223/101800223.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Madan, Smolyan Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"274e6cb680f4c4fdce08c164c19ae481",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614135,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041c\u0430\u0434\u0430\u043d",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/800/227/101800227.geojson
+++ b/data/101/800/227/101800227.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":249898
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d351064f533f4c935b612300d315c9f",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101800227,
-    "wof:lastmodified":1566614128,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0413\u044c\u043e\u0432\u0440\u0435\u043d",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/800/289/101800289.geojson
+++ b/data/101/800/289/101800289.geojson
@@ -98,6 +98,9 @@
         "wd:id":"Q2487502"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c295b4a08cc279effa5e97174e78ecfe",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614128,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0411\u0430\u043d\u044f",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/800/303/101800303.geojson
+++ b/data/101/800/303/101800303.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Gorno Dryanovo"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa04e701edc9ef6dcc7f7a9dbf828fdc",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101800303,
-    "wof:lastmodified":1566614132,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0413\u043e\u0440\u043d\u043e \u0414\u0440\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/800/371/101800371.geojson
+++ b/data/101/800/371/101800371.geojson
@@ -101,6 +101,9 @@
         "qs_pg:id":1083323
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed9296ad1a7e4f9dc09a40dbb4b509fb",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614131,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0414\u043e\u043b\u043d\u043e \u041e\u0441\u0435\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/800/375/101800375.geojson
+++ b/data/101/800/375/101800375.geojson
@@ -91,6 +91,9 @@
         "qs_pg:id":1018247
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b69f487ea55e93db472dbe915e2601ef",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101800375,
-    "wof:lastmodified":1566614139,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041a\u0440\u0430\u0438\u0449\u0435",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/800/403/101800403.geojson
+++ b/data/101/800/403/101800403.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Sarnitsa, Pazardzhik Province"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e6e478c7f665e2aa6da1604bf314f13",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614137,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0421\u044a\u0440\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/800/407/101800407.geojson
+++ b/data/101/800/407/101800407.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q1086756"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c824374a7b92439e4d049950cba345ee",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614130,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0414\u0440\u0430\u0433\u0438\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/836/623/101836623.geojson
+++ b/data/101/836/623/101836623.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Dupnitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d2e2974adb225ea1bab3d8ca2ef301b",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614143,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0414\u0443\u043f\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/836/635/101836635.geojson
+++ b/data/101/836/635/101836635.geojson
@@ -98,6 +98,9 @@
         "wd:id":"Q1130763"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"efbd389cb0a9a85db98116ee5a513199",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614142,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0412\u0430\u0440\u0432\u0430\u0440\u0430",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/836/641/101836641.geojson
+++ b/data/101/836/641/101836641.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Stamboliyski"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf3342fa3d0f80948d9a0afd29cc26bd",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614143,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0421\u0442\u0430\u043c\u0431\u043e\u043b\u0438\u0439\u0441\u043a\u0438",
     "wof:parent_id":85681779,
     "wof:placetype":"locality",

--- a/data/101/836/653/101836653.geojson
+++ b/data/101/836/653/101836653.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Zlatitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2648f008698868b86da1a322c1c2785c",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614144,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0417\u043b\u0430\u0442\u0438\u0446\u0430",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/836/655/101836655.geojson
+++ b/data/101/836/655/101836655.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Pirdop"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ab0cc75bdc684212a7fa0613ff1b191",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614143,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041f\u0438\u0440\u0434\u043e\u043f",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/836/657/101836657.geojson
+++ b/data/101/836/657/101836657.geojson
@@ -262,6 +262,9 @@
         "wk:page":"Nesebar"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1869b70094f85548f1cbaa8656c3c47",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614142,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041d\u0435\u0441\u0435\u0431\u044a\u0440",
     "wof:parent_id":85681805,
     "wof:placetype":"locality",

--- a/data/101/836/663/101836663.geojson
+++ b/data/101/836/663/101836663.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Lom Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c8e4b77a64b5e4a041328da995091d2",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614143,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041b\u043e\u043c",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/836/667/101836667.geojson
+++ b/data/101/836/667/101836667.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Gorna Oryahovitsa"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3fc5103dcd5b7a2bf2b8eea20d7a1d32",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":101836667,
-    "wof:lastmodified":1566614142,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0413\u043e\u0440\u043d\u0430 \u041e\u0440\u044f\u0445\u043e\u0432\u0438\u0446\u0430",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/836/669/101836669.geojson
+++ b/data/101/836/669/101836669.geojson
@@ -138,6 +138,9 @@
         "wd:id":"Q406869"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2444f03b1cb4aebd784dab01a866cabc",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614141,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041b\u044f\u0441\u043a\u043e\u0432\u0435\u0446",
     "wof:parent_id":85681829,
     "wof:placetype":"locality",

--- a/data/101/836/671/101836671.geojson
+++ b/data/101/836/671/101836671.geojson
@@ -141,6 +141,9 @@
         "wd:id":"Q407330"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49ed09906d81edba6f02b261efd8d944",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614143,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0427\u0435\u0440\u0432\u0435\u043d \u0431\u0440\u044f\u0433",
     "wof:parent_id":85681835,
     "wof:placetype":"locality",

--- a/data/101/846/491/101846491.geojson
+++ b/data/101/846/491/101846491.geojson
@@ -155,6 +155,9 @@
         "wk:page":"Svoge"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4165bcbc6735c91389ade3ace536a476",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614122,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u0421\u0432\u043e\u0433\u0435",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/846/497/101846497.geojson
+++ b/data/101/846/497/101846497.geojson
@@ -160,6 +160,9 @@
         "wd:id":"Q406050"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a8ef939978d5096d978cfd3fc6f0973",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614121,
+    "wof:lastmodified":1582345674,
     "wof:name":"\u0414\u0440\u044f\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681797,
     "wof:placetype":"locality",

--- a/data/101/846/499/101846499.geojson
+++ b/data/101/846/499/101846499.geojson
@@ -65,6 +65,9 @@
         "wk:page":"Yablanitsa Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6486f34012b74a14ad832429dcb8cb30",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534985847,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u042f\u0431\u043b\u0430\u043d\u0438\u0446\u0430",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/846/513/101846513.geojson
+++ b/data/101/846/513/101846513.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Yakimovo Municipality"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f9e8ade32f3594cdeb8d205be9771d2b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614123,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u042f\u043a\u0438\u043c\u043e\u0432\u043e",
     "wof:parent_id":85681821,
     "wof:placetype":"locality",

--- a/data/101/848/133/101848133.geojson
+++ b/data/101/848/133/101848133.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q1027607"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e307a7432d88634e8ed86e2022e2fcd",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101848133,
-    "wof:lastmodified":1566614123,
+    "wof:lastmodified":1582345675,
     "wof:name":"\u041f\u0430\u043d\u0447\u0430\u0440\u0435\u0432\u043e",
     "wof:parent_id":85681771,
     "wof:placetype":"locality",

--- a/data/101/857/917/101857917.geojson
+++ b/data/101/857/917/101857917.geojson
@@ -126,6 +126,10 @@
         "wk:page":"Banite"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7dc1c8985d15f4f52befc92a7048cb4a",
     "wof:hierarchy":[
         {
@@ -139,7 +143,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614113,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0411\u0430\u043d\u0438\u0442\u0435",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/857/919/101857919.geojson
+++ b/data/101/857/919/101857919.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q4294183"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3efbbcb9401949bfe582957071382234",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041c\u0438\u043d\u0437\u0443\u0445\u0430\u0440",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/857/921/101857921.geojson
+++ b/data/101/857/921/101857921.geojson
@@ -55,6 +55,9 @@
         "qs_pg:id":2
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ba323f82a7fcc62715338164c608768",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":101857921,
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0411\u0438\u0441\u0442\u0440\u0438\u0446\u0430",
     "wof:parent_id":85681753,
     "wof:placetype":"locality",

--- a/data/101/857/925/101857925.geojson
+++ b/data/101/857/925/101857925.geojson
@@ -135,6 +135,9 @@
         "wd:id":"Q407705"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20c08cf7adddbe37e10ffacec5f3e915",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":101857925,
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0411\u0435\u043b\u043e\u0432\u043e",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/857/927/101857927.geojson
+++ b/data/101/857/927/101857927.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4505325"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cdf398fb7b5dcfdde2a4dae430e95083",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0426\u0435\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/857/929/101857929.geojson
+++ b/data/101/857/929/101857929.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Lakatnik"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2d8d0e9b1ead8bffbc78996b5fe444b",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041b\u0430\u043a\u0430\u0442\u043d\u0438\u043a",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/857/931/101857931.geojson
+++ b/data/101/857/931/101857931.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q2653732"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ca291838166b3f54279c72595d8024d",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101857931,
-    "wof:lastmodified":1566614112,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0418\u0441\u043a\u0440\u0435\u0446",
     "wof:parent_id":85681785,
     "wof:placetype":"locality",

--- a/data/101/857/933/101857933.geojson
+++ b/data/101/857/933/101857933.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q2453987"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09c6faed9f2fb93d9365cf744124ea0a",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101857933,
-    "wof:lastmodified":1561837452,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0411\u0435\u0436\u0430\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/101/859/017/101859017.geojson
+++ b/data/101/859/017/101859017.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q2014606"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d172422452a21ae927d04cc0e23d81a0",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101859017,
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0413\u0440\u043e\u0445\u043e\u0442\u043d\u043e",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/859/019/101859019.geojson
+++ b/data/101/859/019/101859019.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Erma Reka (village)"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1ded74833bcf9261f1a533806e1a62a",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614111,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0415\u0440\u043c\u0430 \u0440\u0435\u043a\u0430",
     "wof:parent_id":85681739,
     "wof:placetype":"locality",

--- a/data/101/859/023/101859023.geojson
+++ b/data/101/859/023/101859023.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q2454163"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"662ba62e34f81ba2df24cea7c498ebbb",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614109,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0411\u0435\u043b\u0438 \u0432\u0438\u0440",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/025/101859025.geojson
+++ b/data/101/859/025/101859025.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q2461682"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13486c2aac709ff918fe22c223e69709",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101859025,
-    "wof:lastmodified":1566614109,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0421\u0438\u043f\u0435\u0439",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/027/101859027.geojson
+++ b/data/101/859/027/101859027.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q1083857"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c4e69f7e42e9fe783b31d2791cc5233",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101859027,
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0420\u0435\u0437\u0431\u0430\u0440\u0446\u0438",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/029/101859029.geojson
+++ b/data/101/859/029/101859029.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q1084594"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5447e97ac8199679ba30ae807e2903d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101859029,
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041a\u043e\u0431\u0438\u043b\u044f\u043d\u0435",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/031/101859031.geojson
+++ b/data/101/859/031/101859031.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Gorna Kula"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"800d563f8b53d6008b9431fe86e33de2",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0413\u043e\u0440\u043d\u0430 \u043a\u0443\u043b\u0430",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/033/101859033.geojson
+++ b/data/101/859/033/101859033.geojson
@@ -94,6 +94,9 @@
         "wd:id":"Q1083873"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4451ea8d18a63ffe8454eb6fb9cb58e",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614111,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0421\u0438\u043d\u0434\u0435\u043b\u0446\u0438",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/035/101859035.geojson
+++ b/data/101/859/035/101859035.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4395398"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eec16a6a80bbfdd04041fffd39b269b",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614111,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u0420\u043e\u0433\u0430\u0447",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/037/101859037.geojson
+++ b/data/101/859/037/101859037.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4231945"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d4324056a68e798a27c33fd8e82f33c",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041a\u043e\u043d\u0447\u0435",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/041/101859041.geojson
+++ b/data/101/859/041/101859041.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q1082923"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a4a1ea079bd9705bab0f77877e2b7dc",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614109,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0417\u0432\u044a\u043d\u0430\u0440\u043a\u0430",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/043/101859043.geojson
+++ b/data/101/859/043/101859043.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4440152"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2817a800dc1d793e711b2e4c6bb35cc",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0421\u0442\u0430\u0440\u043e\u0432\u043e",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/045/101859045.geojson
+++ b/data/101/859/045/101859045.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4129126"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3543e41d4612cc9a10137ce5d2ffcc59",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101859045,
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0412\u044a\u0440\u0431\u0435\u043d",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/047/101859047.geojson
+++ b/data/101/859/047/101859047.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q1084408"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0dcadd78c496a1a2fa788ffe5adc57a",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614109,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0413\u043e\u043b\u044f\u043c\u0430 \u0447\u0438\u043d\u043a\u0430",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/049/101859049.geojson
+++ b/data/101/859/049/101859049.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q4492173"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5cd132a89daa1d54aece06a82c042bea",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614109,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u0424\u043e\u0442\u0438\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/051/101859051.geojson
+++ b/data/101/859/051/101859051.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q1083429"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c24662c7f73beed764d5feda7ec62816",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614111,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041a\u0438\u0442\u043d\u0430",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/053/101859053.geojson
+++ b/data/101/859/053/101859053.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q1083214"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a73f219940efc61bef717162b56ea58",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041c\u043e\u0433\u0438\u043b\u044f\u043d\u0435",
     "wof:parent_id":85681745,
     "wof:placetype":"locality",

--- a/data/101/859/055/101859055.geojson
+++ b/data/101/859/055/101859055.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Pokrovnik"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35d7a3344e852c8b7c07faf700a32aba",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614110,
+    "wof:lastmodified":1582345671,
     "wof:name":"\u041f\u043e\u043a\u0440\u043e\u0432\u043d\u0438\u043a",
     "wof:parent_id":85681749,
     "wof:placetype":"locality",

--- a/data/101/859/059/101859059.geojson
+++ b/data/101/859/059/101859059.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q1086590"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b1988f80ec96d4b96a7030696d1209d",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614111,
+    "wof:lastmodified":1582345672,
     "wof:name":"\u041a\u0440\u044a\u0441\u0442\u0430\u0432\u0430",
     "wof:parent_id":85681763,
     "wof:placetype":"locality",

--- a/data/101/910/941/101910941.geojson
+++ b/data/101/910/941/101910941.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Kamen Bryag"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d5e1e6b78848b9cf01b7e1812442142",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101910941,
-    "wof:lastmodified":1566614145,
+    "wof:lastmodified":1582345675,
     "wof:name":"Kamen Bryag",
     "wof:parent_id":85681865,
     "wof:placetype":"locality",

--- a/data/117/561/058/1/1175610581.geojson
+++ b/data/117/561/058/1/1175610581.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q2453987"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09c6faed9f2fb93d9365cf744124ea0a",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":1175610581,
-    "wof:lastmodified":1566613945,
+    "wof:lastmodified":1582345661,
     "wof:name":"\u0411\u0435\u0436\u0430\u043d\u043e\u0432\u043e",
     "wof:parent_id":85681811,
     "wof:placetype":"locality",

--- a/data/856/330/01/85633001.geojson
+++ b/data/856/330/01/85633001.geojson
@@ -1134,6 +1134,10 @@
     },
     "wof:country":"BG",
     "wof:country_alpha3":"BGR",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"a783b9397d459792baa4c1511c0cf7d7",
     "wof:hierarchy":[
         {
@@ -1148,7 +1152,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1566613711,
+    "wof:lastmodified":1582345657,
     "wof:name":"Bulgaria",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/014/07/85901407.geojson
+++ b/data/859/014/07/85901407.geojson
@@ -132,6 +132,10 @@
         "wd:id":"Q753441"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0f1209c6b99e4e14bd104ab812a2abf",
     "wof:hierarchy":[
         {
@@ -146,7 +150,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Atanasovo",
     "wof:parent_id":101748905,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/11/85901411.geojson
+++ b/data/859/014/11/85901411.geojson
@@ -97,6 +97,10 @@
         "wk:page":"Boyana"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb04ea77c3e9a0d2771292fc620ce0a9",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Vitosha",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/13/85901413.geojson
+++ b/data/859/014/13/85901413.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":983581
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed82a560045667dfdcb8b319024b624f",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Chitakovi Kolibi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/15/85901415.geojson
+++ b/data/859/014/15/85901415.geojson
@@ -101,6 +101,10 @@
         "wd:id":"Q10270041"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e54fccc36820b7be4cd35622d64c5540",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Darvenitsa",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/17/85901417.geojson
+++ b/data/859/014/17/85901417.geojson
@@ -81,6 +81,9 @@
         "gp:id":836262
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15038e5431eac0ba9cb542dc92f8047d",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Gara Iskar",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/19/85901419.geojson
+++ b/data/859/014/19/85901419.geojson
@@ -92,6 +92,10 @@
         "qs_pg:id":1167293
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd248e39720d79b76d23d272fe4385a6",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Gramada",
     "wof:parent_id":101748875,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/21/85901421.geojson
+++ b/data/859/014/21/85901421.geojson
@@ -88,6 +88,10 @@
         "qs_pg:id":1167297
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91700c65f41c334b747245ef132fd6df",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Kolyu Ganchevo",
     "wof:parent_id":101748895,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/23/85901423.geojson
+++ b/data/859/014/23/85901423.geojson
@@ -96,6 +96,10 @@
         "wd:id":"Q6436239"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fda707316fe81c092c03773aa05d57a0",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Krasno Selo",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/25/85901425.geojson
+++ b/data/859/014/25/85901425.geojson
@@ -102,6 +102,10 @@
         "wd:id":"Q8014589"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc021cefb76d85e9ccf357695367c6e8",
     "wof:hierarchy":[
         {
@@ -116,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Malashevtsi",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/29/85901429.geojson
+++ b/data/859/014/29/85901429.geojson
@@ -96,6 +96,10 @@
         "wd:id":"Q7780690"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a9f62557a614d850d28d534fcff742a",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Moderno Predgradie",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/31/85901431.geojson
+++ b/data/859/014/31/85901431.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Nadezhda, Sofia"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4bd7163a3127fd08bfb7cccc48d3edb",
     "wof:hierarchy":[
         {
@@ -109,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Nadezhda",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/33/85901433.geojson
+++ b/data/859/014/33/85901433.geojson
@@ -87,6 +87,9 @@
         "gp:id":838417
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29da211537c78f50dc666d1ef193ab81",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Obelya",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/35/85901435.geojson
+++ b/data/859/014/35/85901435.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":892202
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0acdfdc69a8748ef900f4b06467a98c6",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613706,
+    "wof:lastmodified":1582345656,
     "wof:name":"Obraztsov Chiflik",
     "wof:parent_id":101748923,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/37/85901437.geojson
+++ b/data/859/014/37/85901437.geojson
@@ -98,6 +98,9 @@
         "gp:id":839133
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7f791e766d493b41a716ba686529705",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Rakovski",
     "wof:parent_id":101797991,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/39/85901439.geojson
+++ b/data/859/014/39/85901439.geojson
@@ -164,6 +164,10 @@
         "qs_pg:id":278015
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd3a0d22b3a8d20a856bc830e9f6a981",
     "wof:hierarchy":[
         {
@@ -178,7 +182,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Slatina",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/41/85901441.geojson
+++ b/data/859/014/41/85901441.geojson
@@ -71,6 +71,9 @@
         "gp:id":840160
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d92e8f3ebe227e7c7c6bc472b0341c14",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Tonchevtsi",
     "wof:parent_id":101748901,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/43/85901443.geojson
+++ b/data/859/014/43/85901443.geojson
@@ -184,6 +184,10 @@
         "qs_pg:id":313392
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9ccf8059b129e9cc20c58759e2298dc",
     "wof:hierarchy":[
         {
@@ -198,7 +202,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345656,
     "wof:name":"Vasil Levski",
     "wof:parent_id":101796285,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/47/85901447.geojson
+++ b/data/859/014/47/85901447.geojson
@@ -170,6 +170,10 @@
         "wd:id":"Q7780633"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"850fa5755efe365deec63efa177184b6",
     "wof:hierarchy":[
         {
@@ -184,7 +188,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Vrazhdebna",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/49/85901449.geojson
+++ b/data/859/014/49/85901449.geojson
@@ -111,6 +111,10 @@
         "wd:id":"Q7780690"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ace97f5a5337ecb2d2413902575a575d",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613708,
+    "wof:lastmodified":1582345657,
     "wof:name":"Vrabnitsa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/51/85901451.geojson
+++ b/data/859/014/51/85901451.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":491828
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"20f0025cb284c27786651b8265298033",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613707,
+    "wof:lastmodified":1582345656,
     "wof:name":"Yordan Yovkovo",
     "wof:parent_id":101748925,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/49/85929249.geojson
+++ b/data/859/292/49/85929249.geojson
@@ -97,6 +97,10 @@
         "wd:id":"Q5426161"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"84192c2b708de59000e4a5dad92c52a9",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Ilinden",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/53/85929253.geojson
+++ b/data/859/292/53/85929253.geojson
@@ -88,6 +88,10 @@
         "wd:id":"Q7917652"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1413200368580431349dd5d90d01219f",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Vazrazhdane",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/59/85929259.geojson
+++ b/data/859/292/59/85929259.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":224252
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eed73c3ee77ed932bf69cbdb322eb97",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Krasna Polyana",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/63/85929263.geojson
+++ b/data/859/292/63/85929263.geojson
@@ -94,6 +94,10 @@
         "wd:id":"Q7207186"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"027f8b1602214e90ad77b4243d11216d",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Poduyane",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/69/85929269.geojson
+++ b/data/859/292/69/85929269.geojson
@@ -96,6 +96,9 @@
         "gp:id":55855472
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c99e32f492027b3bf3261efb71eb93",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Oborishte",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/75/85929275.geojson
+++ b/data/859/292/75/85929275.geojson
@@ -90,6 +90,10 @@
         "wd:id":"Q7113283"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1698adff90a5bcde33c2c78f8a93a13",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Ovcha Kupel",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/79/85929279.geojson
+++ b/data/859/292/79/85929279.geojson
@@ -88,6 +88,10 @@
         "wd:id":"Q12281451"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c877a04782d85ca939f344eb65391fc0",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Izgrev",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/83/85929283.geojson
+++ b/data/859/292/83/85929283.geojson
@@ -96,6 +96,10 @@
         "qs_pg:id":1080170
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0755cdb212a05981b9565baa8da1d210",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Lozenets",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/87/85929287.geojson
+++ b/data/859/292/87/85929287.geojson
@@ -88,6 +88,10 @@
         "wd:id":"Q3658300"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e786e0064ccb84eb68a06e75be0f317",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Triaditsa",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/93/85929293.geojson
+++ b/data/859/292/93/85929293.geojson
@@ -181,6 +181,9 @@
         "wd:id":"Q378943"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3be599078d3ff9ab7be803adee8eca64",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613709,
+    "wof:lastmodified":1582345657,
     "wof:name":"Vitosha",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/97/85929297.geojson
+++ b/data/859/292/97/85929297.geojson
@@ -97,6 +97,10 @@
         "wd:id":"Q6885639"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5af20eb9050f78de43261d6bd0020fdb",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Mladost",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/01/85929301.geojson
+++ b/data/859/293/01/85929301.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q19610982"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"378374d3db7328c8649ba2138a416feb",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Lyulin",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/03/85929303.geojson
+++ b/data/859/293/03/85929303.geojson
@@ -82,6 +82,10 @@
         "wd:id":"Q3500923"
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a795a154b9eea47a7d7f48bcf652b403",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Studentski",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/07/85929307.geojson
+++ b/data/859/293/07/85929307.geojson
@@ -100,6 +100,9 @@
         "gp:id":55855483
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72fbf93214156f94c3fdd613afb0de64",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566613710,
+    "wof:lastmodified":1582345657,
     "wof:name":"Iskar",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/13/85929313.geojson
+++ b/data/859/293/13/85929313.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":897354
     },
     "wof:country":"BG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e16285bae8217b0537edc73a57a7784b",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578084080,
+    "wof:lastmodified":1582345657,
     "wof:name":"Sredets",
     "wof:parent_id":101748887,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.