### PR TITLE
Schmidek patch 1

### DIFF
--- a/data/856/817/71/85681771.geojson
+++ b/data/856/817/71/85681771.geojson
@@ -25,7 +25,7 @@
     "geom:longitude":23.398601,
     "iso:country":"BG",
     "label:eng_x_preferred_longname":[
-        "\u0421\u043e\u0444\u0438\u044f (\u0441\u0442\u043e\u043b\u0438\u0446\u0430) Region"
+        "Sofia City Province"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -59,10 +59,7 @@
         "Liste der bulgarischen Orden und Ehrenzeichen"
     ],
     "name:eng_x_preferred":[
-        "Sofiya"
-    ],
-    "name:eng_x_variant":[
-        "Orders"
+        "Sofia City"
     ],
     "name:nob_x_preferred":[
         "Bulgarias ordensvesen"
@@ -188,7 +185,7 @@
         "hasc:id":"BG.SF",
         "iso:id":"BG-23",
         "unlc:id":"BG-22",
-        "wd:id":"Q983760"
+        "wd:id":"Q1585725"
     },
     "wof:country":"BG",
     "wof:geomhash":"10be1cff26675942a0ed641bcea7c3e6",

--- a/data/856/817/71/85681771.geojson
+++ b/data/856/817/71/85681771.geojson
@@ -24,6 +24,12 @@
     "geom:latitude":42.67833,
     "geom:longitude":23.398601,
     "iso:country":"BG",
+    "label:bul_x_preferred_longname":[
+        "\u041e\u0431\u043b\u0430\u0441\u0442 \u0421\u043e\u0444\u0438\u044f-\u0433\u0440\u0430\u0434"
+    ],
+    "label:bul_x_preferred_placetype":[
+        "\u041e\u0431\u043b\u0430\u0441\u0442"
+    ],
     "label:eng_x_preferred_longname":[
         "Sofia City Province"
     ],
@@ -43,12 +49,12 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:bul_x_preferred":[
-        "\u041d\u0430\u0433\u0440\u0430\u0434\u0438 \u043d\u0430 \u0411\u044a\u043b\u0433\u0430\u0440\u0438\u044f"
+        "\u0421\u043e\u0444\u0438\u044f-\u0433\u0440\u0430\u0434"
     ],
     "name:bul_x_variant":[
         "\u041e\u0431\u043b\u0430\u0441\u0442 \u0421\u043e\u0444\u0438\u044f \u0433\u0440\u0430\u0434",
-        "\u0421\u043e\u0444\u0438\u044f-\u0433\u0440\u0430\u0434",
         "Okr\u016dg Grad Sofiya",
+        "\u0421\u043e\u0444\u0438\u044f (\u0441\u0442\u043e\u043b\u0438\u0446\u0430)",
         "Sofia-Grad",
         "Oblast Sofia-Grad",
         "\u041e\u0431\u043b\u0430\u0441\u0442 \u0421\u043e\u0444\u0438\u044f-\u0413\u0440\u0430\u0434",
@@ -56,10 +62,14 @@
         "\u041e\u0442\u043b\u0438\u0447\u0438\u044f \u043d\u0430 \u0411\u044a\u043b\u0433\u0430\u0440\u0438\u044f"
     ],
     "name:deu_x_preferred":[
-        "Liste der bulgarischen Orden und Ehrenzeichen"
+        "Oblast Sofia-Stadt"
     ],
     "name:eng_x_preferred":[
         "Sofia City"
+    ],
+    "name:eng_x_variant":[
+        "Sofia",
+        "Orders"
     ],
     "name:nob_x_preferred":[
         "Bulgarias ordensvesen"
@@ -188,7 +198,7 @@
         "wd:id":"Q1585725"
     },
     "wof:country":"BG",
-    "wof:geomhash":"10be1cff26675942a0ed641bcea7c3e6",
+    "wof:geomhash":"081b68880d25cbe3e4b54842534ceac1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -203,8 +213,8 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1684351494,
-    "wof:name":"\u0421\u043e\u0444\u0438\u044f (\u0441\u0442\u043e\u043b\u0438\u0446\u0430)",
+    "wof:lastmodified":1694313480,
+    "wof:name":"Sofia City",
     "wof:parent_id":85633001,
     "wof:placetype":"region",
     "wof:placetype_local":"region",


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-bg/pull/14.

This PR updates the names and labels in the record for Sofia City Province, Bulgaria.

https://en.wikipedia.org/wiki/Sofia_City_Province

**Number of records updated**: 1