### PR TITLE
bg concordances, placetype local, and more

### DIFF
--- a/data/856/330/01/85633001.geojson
+++ b/data/856/330/01/85633001.geojson
@@ -1334,6 +1334,7 @@
         "hasc:id":"BG",
         "icao:code":"LZ",
         "ioc:id":"BUL",
+        "iso:code":"BG",
         "itu:id":"BUL",
         "loc:id":"n81032254",
         "m49:code":"100",
@@ -1348,6 +1349,7 @@
         "wk:page":"Bulgaria",
         "wmo:id":"BU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BG",
     "wof:country_alpha3":"BGR",
     "wof:geom_alt":[
@@ -1369,7 +1371,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694492228,
+    "wof:lastmodified":1695881341,
     "wof:name":"Bulgaria",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/817/39/85681739.geojson
+++ b/data/856/817/39/85681739.geojson
@@ -404,10 +404,16 @@
         "gn:id":864558,
         "gp:id":20070067,
         "hasc:id":"BG.SM",
+        "iso:code":"BG-21",
         "iso:id":"BG-21",
+        "qs:local_id":"SML",
         "unlc:id":"BG-21",
         "wd:id":"Q2012430"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"6420025b1a3cb4fb8f9b1d8030ad4976",
     "wof:hierarchy":[
@@ -424,7 +430,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Smolyan",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/45/85681745.geojson
+++ b/data/856/817/45/85681745.geojson
@@ -402,10 +402,16 @@
         "gn:id":864553,
         "gp:id":20070053,
         "hasc:id":"BG.KZ",
+        "iso:code":"BG-09",
         "iso:id":"BG-09",
+        "qs:local_id":"KRZ",
         "unlc:id":"BG-09",
         "wd:id":"Q1104675"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"0a617a1e0db555607d2add8751f3c680",
     "wof:hierarchy":[
@@ -422,7 +428,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Kurdzhali",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/49/85681749.geojson
+++ b/data/856/817/49/85681749.geojson
@@ -400,10 +400,16 @@
         "gn:id":733192,
         "gp:id":20070060,
         "hasc:id":"BG.BL",
+        "iso:code":"BG-01",
         "iso:id":"BG-01",
+        "qs:local_id":"BLG",
         "unlc:id":"BG-01",
         "wd:id":"Q804311"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"7e9d446a0ae0be35e7efcb9a18bf9bd8",
     "wof:hierarchy":[
@@ -420,7 +426,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Blagoevgrad",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/53/85681753.geojson
+++ b/data/856/817/53/85681753.geojson
@@ -153,8 +153,14 @@
         "gn:id":864554,
         "gp:id":20070059,
         "hasc:id":"BG.KY",
-        "iso:id":"BG-10"
+        "iso:code":"BG-10",
+        "iso:id":"BG-10",
+        "qs:local_id":"KNL"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"76fff37f7a371e1e3ea8e53d1a9dcd89",
     "wof:hierarchy":[
@@ -171,7 +177,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Kyustendil",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/59/85681759.geojson
+++ b/data/856/817/59/85681759.geojson
@@ -399,10 +399,16 @@
         "gn:id":730436,
         "gp:id":20070073,
         "hasc:id":"BG.KK",
+        "iso:code":"BG-26",
         "iso:id":"BG-26",
+        "qs:local_id":"HKV",
         "unlc:id":"BG-26",
         "wd:id":"Q182809"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"dc20c28a36396aaff14cba6bb4aaa9a3",
     "wof:hierarchy":[
@@ -419,7 +425,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Khaskovo",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/63/85681763.geojson
+++ b/data/856/817/63/85681763.geojson
@@ -390,9 +390,15 @@
         "gn:id":728379,
         "gp:id":20070066,
         "hasc:id":"BG.PZ",
+        "iso:code":"BG-13",
         "iso:id":"BG-13",
+        "qs:local_id":"PAZ",
         "wd:id":"Q2012227"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"4600e0221bbb29d2cfe20c4d07f0247d",
     "wof:hierarchy":[
@@ -409,7 +415,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Pazardzhik",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/67/85681767.geojson
+++ b/data/856/817/67/85681767.geojson
@@ -428,10 +428,16 @@
         "gn:id":728331,
         "gp:id":20070058,
         "hasc:id":"BG.PN",
+        "iso:code":"BG-14",
         "iso:id":"BG-14",
+        "qs:local_id":"PER",
         "unlc:id":"BG-14",
         "wd:id":"Q2012234"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"5d0ce5318892995d3229b771565e9cea",
     "wof:hierarchy":[
@@ -448,7 +454,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Pernik",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/71/85681771.geojson
+++ b/data/856/817/71/85681771.geojson
@@ -199,10 +199,16 @@
         "gn:id":731061,
         "gp:id":20069794,
         "hasc:id":"BG.SF",
+        "iso:code":"BG-23",
         "iso:id":"BG-23",
+        "qs:local_id":"SOF",
         "unlc:id":"BG-22",
         "wd:id":"Q983760"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"10be1cff26675942a0ed641bcea7c3e6",
     "wof:hierarchy":[
@@ -219,7 +225,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Sofiya",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/79/85681779.geojson
+++ b/data/856/817/79/85681779.geojson
@@ -396,10 +396,16 @@
         "gn:id":728194,
         "gp:id":20070068,
         "hasc:id":"BG.PD",
+        "iso:code":"BG-16",
         "iso:id":"BG-16",
+        "qs:local_id":"PDV",
         "unlc:id":"BG-16",
         "wd:id":"Q187874"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"73215b4929442539594ef0ee0544ff1b",
     "wof:hierarchy":[
@@ -416,7 +422,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Plovdiv",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/83/85681783.geojson
+++ b/data/856/817/83/85681783.geojson
@@ -391,10 +391,16 @@
         "gn:id":864559,
         "gp:id":20070054,
         "hasc:id":"BG.SZ",
+        "iso:code":"BG-24",
         "iso:id":"BG-24",
+        "qs:local_id":"SZR",
         "unlc:id":"BG-24",
         "wd:id":"Q2012583"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"b5fd638d0ae7c5f452c186e6346f21a4",
     "wof:hierarchy":[
@@ -411,7 +417,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885190,
     "wof:name":"Stara Zagora",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/85/85681785.geojson
+++ b/data/856/817/85/85681785.geojson
@@ -269,8 +269,14 @@
         "gn:id":727012,
         "gp:id":20070061,
         "hasc:id":"BG.SG",
-        "iso:id":"BG-22"
+        "iso:code":"BG-22",
+        "iso:id":"BG-22",
+        "qs:local_id":"SFO"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"7b6727e0991c5c2ba1b4d749c751df1f",
     "wof:hierarchy":[
@@ -287,7 +293,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885191,
     "wof:name":"Sofia Province",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/93/85681793.geojson
+++ b/data/856/817/93/85681793.geojson
@@ -397,10 +397,16 @@
         "gn:id":864563,
         "gp:id":20070074,
         "hasc:id":"BG.YA",
+        "iso:code":"BG-28",
         "iso:id":"BG-28",
+        "qs:local_id":"JAM",
         "unlc:id":"BG-28",
         "wd:id":"Q220736"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"b445791848b50ddb943c87de66b4a9ef",
     "wof:hierarchy":[
@@ -417,7 +423,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Yambol",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/97/85681797.geojson
+++ b/data/856/817/97/85681797.geojson
@@ -403,10 +403,16 @@
         "gn:id":864552,
         "gp:id":20070062,
         "hasc:id":"BG.GB",
+        "iso:code":"BG-07",
         "iso:id":"BG-07",
+        "qs:local_id":"GAB",
         "unlc:id":"BG-07",
         "wd:id":"Q1007272"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"cfe4d79a4c34b443660a78b94814c7f4",
     "wof:hierarchy":[
@@ -423,7 +429,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Gabrovo",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/817/99/85681799.geojson
+++ b/data/856/817/99/85681799.geojson
@@ -385,10 +385,16 @@
         "gn:id":864557,
         "gp:id":20070049,
         "hasc:id":"BG.SL",
+        "iso:code":"BG-20",
         "iso:id":"BG-20",
+        "qs:local_id":"SLV",
         "unlc:id":"BG-20",
         "wd:id":"Q113120"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"9b9c92b59eb9aaf828142341c330664d",
     "wof:hierarchy":[
@@ -405,7 +411,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Sliven",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/05/85681805.geojson
+++ b/data/856/818/05/85681805.geojson
@@ -401,10 +401,16 @@
         "gn:id":732771,
         "gp:id":20070075,
         "hasc:id":"BG.BR",
+        "iso:code":"BG-02",
         "iso:id":"BG-02",
+        "qs:local_id":"BGS",
         "unlc:id":"BG-02",
         "wd:id":"Q369220"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"33b6a4259d52fa071e9aa7b766a19b0b",
     "wof:hierarchy":[
@@ -421,7 +427,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Burgas",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/11/85681811.geojson
+++ b/data/856/818/11/85681811.geojson
@@ -394,10 +394,16 @@
         "gn:id":729560,
         "gp:id":20070064,
         "hasc:id":"BG.LV",
+        "iso:code":"BG-11",
         "iso:id":"BG-11",
+        "qs:local_id":"LOV",
         "unlc:id":"BG-11",
         "wd:id":"Q6587068"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"994d24aa20760cd84124553584f906ec",
     "wof:hierarchy":[
@@ -414,7 +420,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Lovech",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/15/85681815.geojson
+++ b/data/856/818/15/85681815.geojson
@@ -381,9 +381,15 @@
         "gn:id":727524,
         "gp:id":20070069,
         "hasc:id":"BG.RS",
+        "iso:code":"BG-18",
         "iso:id":"BG-18",
+        "qs:local_id":"RSE",
         "wd:id":"Q1251933"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"2f2f2cf15ee191c5a0fff9baf727ab82",
     "wof:hierarchy":[
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884484,
     "wof:name":"Ruse",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/17/85681817.geojson
+++ b/data/856/818/17/85681817.geojson
@@ -410,10 +410,16 @@
         "gn:id":725713,
         "gp:id":20070057,
         "hasc:id":"BG.VR",
+        "iso:code":"BG-06",
         "iso:id":"BG-06",
+        "qs:local_id":"VRC",
         "unlc:id":"BG-06",
         "wd:id":"Q2012785"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"eb6d417842c20e76d85d993abfe6ad76",
     "wof:hierarchy":[
@@ -430,7 +436,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Vratsa",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/21/85681821.geojson
+++ b/data/856/818/21/85681821.geojson
@@ -358,10 +358,16 @@
         "gn:id":453753,
         "gp:id":20070056,
         "hasc:id":"BG.MT",
+        "iso:code":"BG-12",
         "iso:id":"BG-12",
+        "qs:local_id":"MON",
         "unlc:id":"BG-12",
         "wd:id":"Q2012057"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"4852c93908d36e4175df6b4921bf1389",
     "wof:hierarchy":[
@@ -378,7 +384,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Montana",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/29/85681829.geojson
+++ b/data/856/818/29/85681829.geojson
@@ -405,10 +405,16 @@
         "gn:id":864561,
         "gp:id":20070063,
         "hasc:id":"BG.VT",
+        "iso:code":"BG-04",
         "iso:id":"BG-04",
+        "qs:local_id":"VTR",
         "unlc:id":"BG-04",
         "wd:id":"Q2012621"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"b6b7f42ccce8da481e64bd7daf59519c",
     "wof:hierarchy":[
@@ -425,7 +431,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Veliko Turnovo",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/35/85681835.geojson
+++ b/data/856/818/35/85681835.geojson
@@ -394,10 +394,16 @@
         "gn:id":728204,
         "gp:id":20070065,
         "hasc:id":"BG.PV",
+        "iso:code":"BG-15",
         "iso:id":"BG-15",
+        "qs:local_id":"PVN",
         "unlc:id":"BG-15",
         "wd:id":"Q2012242"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"3ddf9f94faacf2aa850d85147b499753",
     "wof:hierarchy":[
@@ -414,7 +420,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Pleven",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/39/85681839.geojson
+++ b/data/856/818/39/85681839.geojson
@@ -390,10 +390,16 @@
         "gn:id":864560,
         "gp:id":20070072,
         "hasc:id":"BG.TU",
+        "iso:code":"BG-25",
         "iso:id":"BG-25",
+        "qs:local_id":"TGV",
         "unlc:id":"BG-25",
         "wd:id":"Q2012589"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"13e40a7fe15842537d49072b8c4ffec6",
     "wof:hierarchy":[
@@ -410,7 +416,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885191,
     "wof:name":"Turgovishte",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/41/85681841.geojson
+++ b/data/856/818/41/85681841.geojson
@@ -395,10 +395,16 @@
         "gn:id":864562,
         "gp:id":20070055,
         "hasc:id":"BG.VD",
+        "iso:code":"BG-05",
         "iso:id":"BG-05",
+        "qs:local_id":"VID",
         "unlc:id":"BG-05",
         "wd:id":"Q2012772"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"639a65cb179f94ec6573a665e6a76210",
     "wof:hierarchy":[
@@ -415,7 +421,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885192,
     "wof:name":"Vidin",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/47/85681847.geojson
+++ b/data/856/818/47/85681847.geojson
@@ -370,10 +370,16 @@
         "gn:id":726051,
         "gp:id":20070051,
         "hasc:id":"BG.VN",
+        "iso:code":"BG-03",
         "iso:id":"BG-03",
+        "qs:local_id":"VAR",
         "unlc:id":"BG-03",
         "wd:id":"Q183487"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"6f85de149d7a32d64800754b03157578",
     "wof:hierarchy":[
@@ -390,7 +396,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885192,
     "wof:name":"Varna",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/53/85681853.geojson
+++ b/data/856/818/53/85681853.geojson
@@ -389,10 +389,16 @@
         "gn:id":864555,
         "gp:id":20070052,
         "hasc:id":"BG.SH",
+        "iso:code":"BG-27",
         "iso:id":"BG-27",
+        "qs:local_id":"SHU",
         "unlc:id":"BG-27",
         "wd:id":"Q184981"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"e82240145eeb4392a15d95db8ecc3f8c",
     "wof:hierarchy":[
@@ -409,7 +415,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639834,
+    "wof:lastmodified":1695885192,
     "wof:name":"Shumen",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/57/85681857.geojson
+++ b/data/856/818/57/85681857.geojson
@@ -410,10 +410,16 @@
         "gn:id":453751,
         "gp:id":20070071,
         "hasc:id":"BG.RG",
+        "iso:code":"BG-17",
         "iso:id":"BG-17",
+        "qs:local_id":"RAZ",
         "unlc:id":"BG-17",
         "wd:id":"Q2790675"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"de802f91e71e77fc9db10373a08f5a78",
     "wof:hierarchy":[
@@ -430,7 +436,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639835,
+    "wof:lastmodified":1695885192,
     "wof:name":"Razgrad",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/61/85681861.geojson
+++ b/data/856/818/61/85681861.geojson
@@ -338,8 +338,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"BG323"
+        "eurostat:nuts_2021_id":"BG323",
+        "iso:code":"BG-18",
+        "qs:local_id":"RSE"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"518097ff6c5c8c9518cf9ec7ebf3cab8",
     "wof:hierarchy":[
@@ -356,7 +362,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884296,
     "wof:name":"Ruse",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/65/85681865.geojson
+++ b/data/856/818/65/85681865.geojson
@@ -397,10 +397,16 @@
         "gn:id":726419,
         "gp:id":20070050,
         "hasc:id":"BG.DO",
+        "iso:code":"BG-08",
         "iso:id":"BG-08",
+        "qs:local_id":"DOB",
         "unlc:id":"BG-08",
         "wd:id":"Q907395"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"6d53bee3650a023e6a5b2d0382a4a7b4",
     "wof:hierarchy":[
@@ -417,7 +423,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639835,
+    "wof:lastmodified":1695885192,
     "wof:name":"Dobrich",
     "wof:parent_id":85633001,
     "wof:placetype":"region",

--- a/data/856/818/71/85681871.geojson
+++ b/data/856/818/71/85681871.geojson
@@ -389,10 +389,16 @@
         "gn:id":864556,
         "gp:id":20070070,
         "hasc:id":"BG.SI",
+        "iso:code":"BG-19",
         "iso:id":"BG-19",
+        "qs:local_id":"SLS",
         "unlc:id":"BG-19",
         "wd:id":"Q2012423"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BG",
     "wof:geomhash":"1a26d7f62f3b5718d36e169d17a74c62",
     "wof:hierarchy":[
@@ -409,7 +415,7 @@
     "wof:lang_x_spoken":[
         "bul"
     ],
-    "wof:lastmodified":1694639835,
+    "wof:lastmodified":1695885192,
     "wof:name":"Silistra",
     "wof:parent_id":85633001,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.